### PR TITLE
Bug fix: TMGI fixes

### DIFF
--- a/lib/sbi/message.c
+++ b/lib/sbi/message.c
@@ -208,6 +208,8 @@ void ogs_sbi_message_free(ogs_sbi_message_t *message)
         OpenAPI_ue_reg_status_update_rsp_data_free(message->UeRegStatusUpdateRspData);
     if (message->TmgiAllocate)
         OpenAPI_tmgi_allocate_free(message->TmgiAllocate);
+    if (message->TmgiAllocated)
+        OpenAPI_tmgi_allocated_free(message->TmgiAllocated);
     if (message->CreateReqData)
         OpenAPI_create_req_data_free(message->CreateReqData);
     if (message->CreateRspData)
@@ -2635,9 +2637,18 @@ static int parse_json(ogs_sbi_message_t *message,
                 SWITCH(message->h.method)
                 CASE(OGS_SBI_HTTP_METHOD_POST)
                     if (message->res_status == 0) {
+                        /* client request */
                         message->TmgiAllocate =
                             OpenAPI_tmgi_allocate_parseFromJSON(item);
                         if (!message->TmgiAllocate) {
+                            rv = OGS_ERROR;
+                            ogs_error("JSON parse error");
+                        }
+                    } else {
+                        /* server response */
+                        message->TmgiAllocated =
+                            OpenAPI_tmgi_allocated_parseFromJSON(item);
+                        if (!message->TmgiAllocated) {
                             rv = OGS_ERROR;
                             ogs_error("JSON parse error");
                         }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -3258,12 +3258,12 @@ static char *smf_tmgi_gen_random_mbs_service_id(void)
     return mbs_service_id;
 }
 
-// Using the 2024-05-13T13:05:40.483504+00:00 format
+// Using the 2024-05-13T13:05:40.483504Z format (UTC)
 char *smf_tmgi_gen_expiration_time(int validity_seconds)
 {
     char *expiration_time = NULL;
 
-    expiration_time = ogs_sbi_localtime_string(
+    expiration_time = ogs_sbi_gmtime_string(
         ogs_time_now() + ogs_time_from_sec(validity_seconds));
 
     return expiration_time;


### PR DESCRIPTION
This PR fixes a few issues:
1. The expiry time for a TMGI should be expressed as a UTC time, not local time (TS 29.532 Table 6.1.6.2.3-1).
1. The TmgiAllocated structure was not being parsed when received as a response.
1. TmgiAllocated structure was not being freed when the message structure was freed.