### PR TITLE
MB-SMF: Improve duplicate MBS Session Id checks

### DIFF
--- a/lib/proto/types.c
+++ b/lib/proto/types.c
@@ -1168,3 +1168,144 @@ int ogs_pcc_rule_update_qos_from_media(
 
     return OGS_OK;
 }
+
+void ogs_ncgi_free(ogs_ncgi_t *ncgi)
+{
+    if (!ncgi) return;
+    if (ncgi->nr_cell_id) ogs_free(ncgi->nr_cell_id);
+    if (ncgi->nid) ogs_free(ncgi->nid);
+    ogs_free(ncgi);
+}
+
+void ogs_tai_free(ogs_tai_t *tai)
+{
+    if (!tai) return;
+    if (tai->tac) ogs_free(tai->tac);
+    if (tai->nid) ogs_free(tai->nid);
+    ogs_free(tai);
+}
+
+void ogs_ncgi_tai_free(ogs_ncgi_tai_t *ncgi_tai)
+{
+    ogs_ncgi_t *next, *ncgi;
+
+    if (!ncgi_tai) return;
+    if (ncgi_tai->tai.tac) ogs_free(ncgi_tai->tai.tac);
+    if (ncgi_tai->tai.nid) ogs_free(ncgi_tai->tai.nid);
+    ogs_list_for_each_safe(&ncgi_tai->cell_list, next, ncgi) {
+        ogs_list_remove(&ncgi_tai->cell_list, ncgi);
+        ogs_ncgi_free(ncgi);
+    }
+    ogs_free(ncgi_tai);
+}
+
+void ogs_mbs_service_area_free(ogs_mbs_service_area_t *mbs_service_area)
+{
+    if (!mbs_service_area) return;
+    if (mbs_service_area->ncgi_tai_list) {
+        ogs_ncgi_tai_t *ncgi_tai, *next;
+        ogs_list_for_each_safe(mbs_service_area->ncgi_tai_list, next, ncgi_tai) {
+            ogs_list_remove(mbs_service_area->ncgi_tai_list, ncgi_tai);
+            ogs_ncgi_tai_free(ncgi_tai);
+        }
+        ogs_free(mbs_service_area->ncgi_tai_list);
+    }
+    if (mbs_service_area->tai_list) {
+        ogs_tai_t *tai, *next;
+        ogs_list_for_each_safe(mbs_service_area->tai_list, next, tai) {
+            ogs_list_remove(mbs_service_area->tai_list, tai);
+            ogs_tai_free(tai);
+        }
+        ogs_free(mbs_service_area->tai_list);
+    }
+    ogs_free(mbs_service_area);
+}
+
+void ogs_geographic_area_free(ogs_geographic_area_t *geographic_area)
+{
+    if (!geographic_area) return;
+    switch (geographic_area->shape) {
+    case ogs_supported_gad_shape_POINT:
+    case ogs_supported_gad_shape_POINT_UNCERTAINTY_CIRCLE:
+    case ogs_supported_gad_shape_POINT_UNCERTAINTY_ELLIPSE:
+    case ogs_supported_gad_shape_POINT_ALTITUDE:
+    case ogs_supported_gad_shape_POINT_ALTITUDE_UNCERTAINTY:
+    case ogs_supported_gad_shape_ELLIPSOID_ARC:
+        /* nothing extra to free */
+        break;
+    case ogs_supported_gad_shape_POLYGON:
+        {
+            /* free list of polygon points */
+            ogs_geographic_coordinates_t *coord, *next;
+            ogs_list_for_each_safe(&geographic_area->polygon.point_list, next, coord) {
+                ogs_list_remove(&geographic_area->polygon.point_list, coord);
+                ogs_free(coord);
+            }
+        }
+        break;
+    default:
+        ogs_warn("ogs_geographic_area_free: Unsupported Geographic Area shape");
+    }
+    ogs_free(geographic_area);
+}
+
+void ogs_civic_address_free(ogs_civic_address_t *civic_address)
+{
+    int i;
+
+    if (!civic_address) return;
+    if (civic_address->country) ogs_free(civic_address->country);
+    for (i=0; i<6; i++)
+        if (civic_address->a[i]) ogs_free(civic_address->a[i]);
+    if (civic_address->prd) ogs_free(civic_address->prd);
+    if (civic_address->pod) ogs_free(civic_address->pod);
+    if (civic_address->sts) ogs_free(civic_address->sts);
+    if (civic_address->hno) ogs_free(civic_address->hno);
+    if (civic_address->hns) ogs_free(civic_address->hns);
+    if (civic_address->lmk) ogs_free(civic_address->lmk);
+    if (civic_address->loc) ogs_free(civic_address->loc);
+    if (civic_address->nam) ogs_free(civic_address->nam);
+    if (civic_address->pc) ogs_free(civic_address->pc);
+    if (civic_address->bld) ogs_free(civic_address->bld);
+    if (civic_address->unit) ogs_free(civic_address->unit);
+    if (civic_address->flr) ogs_free(civic_address->flr);
+    if (civic_address->room) ogs_free(civic_address->room);
+    if (civic_address->plc) ogs_free(civic_address->plc);
+    if (civic_address->pcn) ogs_free(civic_address->pcn);
+    if (civic_address->pobox) ogs_free(civic_address->pobox);
+    if (civic_address->addcode) ogs_free(civic_address->addcode);
+    if (civic_address->seat) ogs_free(civic_address->seat);
+    if (civic_address->rd) ogs_free(civic_address->rd);
+    if (civic_address->rdsec) ogs_free(civic_address->rdsec);
+    if (civic_address->rdbr) ogs_free(civic_address->rdbr);
+    if (civic_address->rdsubbr) ogs_free(civic_address->rdsubbr);
+    if (civic_address->prm) ogs_free(civic_address->prm);
+    if (civic_address->pom) ogs_free(civic_address->pom);
+    if (civic_address->usage_rules) ogs_free(civic_address->usage_rules);
+    if (civic_address->method) ogs_free(civic_address->method);
+    if (civic_address->provided_by) ogs_free(civic_address->provided_by);
+    ogs_free(civic_address);
+}
+
+void ogs_ext_mbs_service_area_free(ogs_ext_mbs_service_area_t *ext_mbs_service_area)
+{
+    if (!ext_mbs_service_area) return;
+    if (ext_mbs_service_area->geographic_area_list) {
+        ogs_geographic_area_t *geog_area, *next;
+        ogs_list_for_each_safe(ext_mbs_service_area->geographic_area_list, next, geog_area) {
+            ogs_list_remove(ext_mbs_service_area->geographic_area_list, geog_area);
+            ogs_geographic_area_free(geog_area);
+        }
+        ogs_free(ext_mbs_service_area->geographic_area_list);
+        ext_mbs_service_area->geographic_area_list = NULL;
+    }
+    if (ext_mbs_service_area->civic_address_list) {
+        ogs_civic_address_t *civic_address, *next;
+        ogs_list_for_each_safe(ext_mbs_service_area->civic_address_list, next, civic_address) {
+            ogs_list_remove(ext_mbs_service_area->civic_address_list, civic_address);
+            ogs_civic_address_free(civic_address);
+        }
+        ogs_free(ext_mbs_service_area->civic_address_list);
+        ext_mbs_service_area->civic_address_list = NULL;
+    }
+}

--- a/lib/proto/types.c
+++ b/lib/proto/types.c
@@ -1308,4 +1308,5 @@ void ogs_ext_mbs_service_area_free(ogs_ext_mbs_service_area_t *ext_mbs_service_a
         ogs_free(ext_mbs_service_area->civic_address_list);
         ext_mbs_service_area->civic_address_list = NULL;
     }
+    ogs_free(ext_mbs_service_area);
 }

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -1027,6 +1027,241 @@ ED3(uint8_t is_tmgi:1;,
     uint8_t spare:6;)
 } ogs_mbs_session_id_t;
 
+/***************************************************
+ * NCGI
+ * 3GPP TS 29.571 Ch. 5.4.4.6 - Ncgi
+ */
+typedef struct ogs_ncgi_s {
+    ogs_lnode_t lnode;           /* A node of list_t */
+    ogs_plmn_id_t plmn_id;
+    char *nr_cell_id;
+    char *nid;
+} ogs_ncgi_t;
+
+void ogs_ncgi_free(ogs_ncgi_t *ncgi);
+
+/***************************************************
+ * TAI
+ * 3GPP TS 29.571 Ch. 5.4.4.4 - Tai
+ */
+typedef struct ogs_tai_s {
+    ogs_lnode_t lnode;           /* A node of list_t */
+    ogs_plmn_id_t plmn_id;
+    char *tac;
+    char *nid;
+} ogs_tai_t;
+
+void ogs_tai_free(ogs_tai_t *tai);
+
+/***************************************************
+ * NCGI TAI
+ * 3GPP TS 29.571 Ch. 5.9.4.5 - NcgiTai
+ */
+typedef struct ogs_ncgi_tai_s {
+    ogs_tai_t tai;        /* TAI contains a node of list_t */
+    ogs_list_t cell_list; /* list of ogs_ncgi_t */
+} ogs_ncgi_tai_t;
+
+void ogs_ncgi_tai_free(ogs_ncgi_tai_t *ncgi_tai);
+
+/***************************************************
+ * MBS Service Area
+ * 3GPP TS 29.571 Ch. 5.9.4.4 - MbsServiceArea
+ */
+typedef struct ogs_mbs_service_area_s {
+    ogs_lnode_t lnode;           /* A node of list_t */
+    ogs_list_t *ncgi_tai_list;   /* list of ogs_ncgi_tai_t */
+    ogs_list_t *tai_list;        /* list of ogs_tai_t */
+} ogs_mbs_service_area_t;
+
+void ogs_mbs_service_area_free(ogs_mbs_service_area_t *mbs_service_area);
+
+/***************************************************
+ * Supported Geographic Area Shapes
+ * 3GPP TS 29.572 Ch. 6.1.6.3.4 - SupportedGADShapes
+ */
+typedef enum ogs_supported_gad_shapes_e {
+    ogs_supported_gad_shape_POINT,
+    ogs_supported_gad_shape_POINT_UNCERTAINTY_CIRCLE,
+    ogs_supported_gad_shape_POINT_UNCERTAINTY_ELLIPSE,
+    ogs_supported_gad_shape_POLYGON,
+    ogs_supported_gad_shape_POINT_ALTITUDE,
+    ogs_supported_gad_shape_POINT_ALTITUDE_UNCERTAINTY,
+    ogs_supported_gad_shape_ELLIPSOID_ARC,
+    ogs_supported_gad_shape_LOCAL_2D_POINT_UNCERTAINTY_ELLIPSE,
+    ogs_supported_gad_shape_LOCAL_3D_POINT_UNCERTAINTY_ELLIPSOID,
+    ogs_supported_gad_shape_DISTANCE_DIRECTION,
+    ogs_supported_gad_shape_RELATIVE_2D_LOCATION_UNCERTAINTY_ELLIPSE,
+    ogs_supported_gad_shape_RELATIVE_3D_LOCATION_UNCERTAINTY_ELLIPSOID
+} ogs_supported_gad_shapes_t;
+
+/***************************************************
+ * Geographic Coordinate
+ * 3GPP TS 29.572 Ch. 6.1.6.2.4 - GeographicCoordinates
+ */
+typedef struct ogs_geographic_coordinates_s {
+    ogs_lnode_t lnode;	/* a node in an ogs_list_t */
+    double lon; /* -180.0 to 180.0 */
+    double lat; /* -90.0 to 90.0 */
+} ogs_geographic_coordinates_t;
+
+/***************************************************
+ * Point (Geographic Area)
+ * 3GPP TS 29.572 Ch. 6.1.6.2.6 - Point
+ */
+typedef struct ogs_point_s {
+    /* shape property handled by ogs_geographic_area_t */
+    ogs_geographic_coordinates_t point;
+} ogs_point_t;
+
+/***************************************************
+ * Point Uncertainty Circle (Geographic Area)
+ * 3GPP TS 29.572 Ch. 6.1.6.2.7 - PointUncertaintyCircle
+ */
+typedef struct ogs_point_uncertainty_circle_s {
+    /* shape property handled by ogs_geographic_area_t */
+    ogs_geographic_coordinates_t point;
+    double uncertainty; /* minimum 0, measured in meters */
+} ogs_point_uncertainty_circle_t;
+
+/***************************************************
+ * Uncertainty Ellipse
+ * 3GPP TS 29.572 Ch. 6.1.6.2.22 - UncertaintyEllipse
+ */
+typedef struct ogs_uncertainty_ellipse_s {
+    double semi_major;        /* minimum 0, measured in meters */
+    double semi_minor;        /* minimum 0, measured in meters */
+    int    orientation_major; /* 0 to 180, measured in degrees */
+} ogs_uncertainty_ellipse_t;
+
+/***************************************************
+ * Point Uncertainty Ellipse (Geographic Area)
+ * 3GPP TS 29.572 Ch. 6.1.6.2.8 - PointUncertaintyEllipse
+ */
+typedef struct ogs_point_uncertainty_ellipse_s {
+    /* shape property handled by ogs_geographic_area_t */
+    ogs_geographic_coordinates_t point;
+    ogs_uncertainty_ellipse_t    uncertainty_ellipse;
+    int                          confidence; /* 0 to 100, measured as a percentage */
+} ogs_point_uncertainty_ellipse_t;
+
+/***************************************************
+ * Polygon (Geographic Area)
+ * 3GPP TS 29.572 Ch. 6.1.6.2.9 - Polygon
+ */
+typedef struct ogs_polygon_s {
+    /* shape property handled by ogs_geographic_area_t */
+    ogs_list_t point_list; /* list of ogs_geographic_coordinates_t, 3 to 15 list entries */
+} ogs_polygon_t;
+
+/***************************************************
+ * Point Altitude (Geographic Area)
+ * 3GPP TS 29.572 Ch. 6.1.6.2.10 - PointAltitude
+ */
+typedef struct ogs_point_altitude_s {
+    /* shape property handled by ogs_geographic_area_t */
+    ogs_geographic_coordinates_t point;
+    double altitude; /* -32767.0 to 32767.0, measured in meters */
+} ogs_point_altitude_t;
+
+/***************************************************
+ * Point Altitude Uncertainty (Geographic Area)
+ * 3GPP TS 29.572 Ch. 6.1.6.2.11 - PointAltitudeUncertainty
+ */
+typedef struct ogs_point_altitude_uncertainty_s {
+    /* shape property handled by ogs_geographic_area_t */
+    ogs_geographic_coordinates_t point;
+    double                       altitude; /* -32767.0 to 32767.0, measured in meters */
+    ogs_uncertainty_ellipse_t    uncertainty_ellipse;
+    double                       uncertainty_altitude; /* minimum 0, measured in meters */
+    int                          confidence; /* 0 to 100, measured as a percentage */
+    int                          v_confidence; /* -1 for not present or 0 to 100, measured as a percentage */
+} ogs_point_altitude_uncertainty_t;
+
+/***************************************************
+ * Ellipsoid Arc (Geographic Area)
+ * 3GPP TS 29.572 Ch. 6.1.6.2.12 - EllipsoidArc
+ */
+typedef struct ogs_ellipsoid_arc_s {
+    /* shape property handled by ogs_geographic_area_t */
+    ogs_geographic_coordinates_t point;
+    int                          inner_radius; /* 0 to 327675, measured in meters */
+    double                       uncertainty_radius; /* minimum 0, measured in meters */
+    int                          offset_angle; /* 0 to 360, measured in degrees */
+    int                          included_angle; /* 0 to 360, measured in degrees */
+    int                          confidence; /* 0 to 100, measured as a percentage */
+} ogs_ellipsoid_arc_t;
+
+/***************************************************
+ * Geographic Area
+ * 3GPP TS 29.572 Ch. 6.1.6.2.5 - GeographicArea
+ */
+typedef struct ogs_geographic_area_s {
+    ogs_lnode_t lnode;			/* A node of list_t */
+    ogs_supported_gad_shapes_t shape;
+    union {
+        ogs_point_t point;
+        ogs_point_uncertainty_circle_t   point_uncertainty_circle;
+        ogs_point_uncertainty_ellipse_t  point_uncertainty_ellipse;
+        ogs_polygon_t                    polygon;
+        ogs_point_altitude_t             point_altitude;
+        ogs_point_altitude_uncertainty_t point_altitude_uncertainty;
+        ogs_ellipsoid_arc_t              ellipsoid_arc;
+    };
+} ogs_geographic_area_t;
+
+void ogs_geographic_area_free(ogs_geographic_area_t *geographic_area);
+
+/***************************************************
+ * Civic Address
+ * 3GPP TS 29.572 Ch. 6.1.6.2.14 - CivicAddress
+ */
+typedef struct ogs_civic_address_s {
+    char *country;
+    char *a[6];
+    char *prd;
+    char *pod;
+    char *sts;
+    char *hno;
+    char *hns;
+    char *lmk;
+    char *loc;
+    char *nam;
+    char *pc;
+    char *bld;
+    char *unit;
+    char *flr;
+    char *room;
+    char *plc;
+    char *pcn;
+    char *pobox;
+    char *addcode;
+    char *seat;
+    char *rd;
+    char *rdsec;
+    char *rdbr;
+    char *rdsubbr;
+    char *prm;
+    char *pom;
+    char *usage_rules;
+    char *method;
+    char *provided_by;
+} ogs_civic_address_t;
+
+void ogs_civic_address_free(ogs_civic_address_t *civic_address);
+
+/***************************************************
+ * External MBS Service Area
+ * 3GPP TS 29.571 Ch. 5.9.4.11 - ExternalMbsServiceArea
+ */
+typedef struct ogs_ext_mbs_service_area_s {
+    ogs_lnode_t lnode;                /* A node of list_t */
+    ogs_list_t *geographic_area_list; /* list of ogs_geographic_area_t */
+    ogs_list_t *civic_address_list;   /* list of ogs_civic_address_t */
+} ogs_ext_mbs_service_area_t;
+
+void ogs_ext_mbs_service_area_free(ogs_ext_mbs_service_area_t *ext_mbs_service_area);
+
 #ifdef __cplusplus
 }
 #endif

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 project('open5gs', 'c', 'cpp',
     version : '2.7.2',
     license : 'AGPL-3.0-or-later',
-    meson_version : '>= 0.43.0',
+    meson_version : '>= 0.63.0',
     default_options : [
         'warning_level=1',
         'c_std=gnu89',

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -51,6 +51,22 @@ static void smf_tmgi_remove_all(void);
 static void smf_mbs_sess_remove(smf_mbs_sess_t *smf_mbs_sess);
 static void smf_mbs_sess_remove_all(void);
 
+static void smf_mbs_sess_list_hash_destroy(ogs_hash_t *mbs_sess_list_hash);
+
+static void smf_mbs_sessions_by_tmgi_add_mbs_sess(smf_mbs_sess_t *mbs_sess);
+static void smf_mbs_sessions_by_tmgi_remove_mbs_sess(smf_mbs_sess_t *mbs_sess);
+static void *smf_mbs_sessions_by_tmgi_key(ogs_tmgi_t *tmgi, int *klen);
+
+static void smf_mbs_sessions_by_ssm_add_mbs_sess(smf_mbs_sess_t *mbs_sess);
+static void smf_mbs_sessions_by_ssm_remove_mbs_sess(smf_mbs_sess_t *mbs_sess);
+static void *smf_mbs_sessions_by_ssm_key(ogs_ssm_t *ssm, int *klen);
+
+static bool smf_mbs_sess_list_service_areas_overlap(ogs_list_t *mbs_sess_list, smf_mbs_sess_t *mbs_session);
+static bool smf_mbs_sess_service_areas_overlap(smf_mbs_sess_t *a, smf_mbs_sess_t *b);
+
+static bool smf_tai_equal(const ogs_tai_t *a, const ogs_tai_t *b);
+static bool smf_ncgi_equal(const ogs_ncgi_t *a, const ogs_ncgi_t *b);
+
 const char smf_mbs_sess_multicast_state_configured[] = "Configured";
 const char smf_mbs_sess_multicast_state_active[] = "Active";
 const char smf_mbs_sess_multicast_state_inactive[] = "Inactive";
@@ -121,8 +137,10 @@ void smf_context_init(void)
     ogs_assert(self.ipv6_hash);
     self.n1n2message_hash = ogs_hash_make();
     ogs_assert(self.n1n2message_hash);
-    self.smf_mbs_sess_by_ssm = ogs_hash_make();
-    ogs_assert(self.smf_mbs_sess_by_ssm);
+    self.smf_mbs_sessions_by_ssm = ogs_hash_make();
+    ogs_assert(self.smf_mbs_sessions_by_ssm);
+    self.smf_mbs_sessions_by_tmgi = ogs_hash_make();
+    ogs_assert(self.smf_mbs_sessions_by_tmgi);
 
     context_initialized = 1;
 }
@@ -148,8 +166,8 @@ void smf_context_final(void)
     ogs_hash_destroy(self.ipv6_hash);
     ogs_assert(self.n1n2message_hash);
     ogs_hash_destroy(self.n1n2message_hash);
-    ogs_assert(self.smf_mbs_sess_by_ssm);
-    ogs_hash_destroy(self.smf_mbs_sess_by_ssm);
+    smf_mbs_sess_list_hash_destroy(self.smf_mbs_sessions_by_ssm);
+    smf_mbs_sess_list_hash_destroy(self.smf_mbs_sessions_by_tmgi);
 
     ogs_pool_final(&smf_ue_pool);
     ogs_pool_final(&smf_bearer_pool);
@@ -176,6 +194,36 @@ void smf_context_final(void)
 smf_context_t *smf_self(void)
 {
     return &self;
+}
+
+bool smf_context_have_matching_mbs_session_id(smf_mbs_sess_t *mbs_session)
+{
+    if (mbs_session->mbs_session_id.is_tmgi) {
+        void *key;
+        int klen;
+
+	ogs_debug("Checking MBS Session ID TMGI");
+        key = smf_mbs_sessions_by_tmgi_key(mbs_session->mbs_session_id.tmgi, &klen);
+        if (key) {
+            ogs_list_t *mbs_sess_list = (ogs_list_t*)ogs_hash_get(self.smf_mbs_sessions_by_tmgi, key, klen);
+	    ogs_debug("Found %i sessions matching TMGI", mbs_sess_list?ogs_list_count(mbs_sess_list):0);
+            if (smf_mbs_sess_list_service_areas_overlap(mbs_sess_list, mbs_session)) return true;
+        }
+    }
+
+    if (mbs_session->mbs_session_id.is_ssm) {
+        void *key;
+        int klen;
+	ogs_debug("Checking MBS Session ID SSM");
+        key = smf_mbs_sessions_by_ssm_key(mbs_session->mbs_session_id.ssm, &klen);
+        if (key) {
+            ogs_list_t *mbs_sess_list = (ogs_list_t*)ogs_hash_get(self.smf_mbs_sessions_by_ssm, key, klen);
+            ogs_debug("Found %i sessions matching SSM", mbs_sess_list?ogs_list_count(mbs_sess_list):0);
+            if (smf_mbs_sess_list_service_areas_overlap(mbs_sess_list, mbs_session)) return true;
+        }
+    }
+
+    return false;
 }
 
 static int smf_context_prepare(void)
@@ -3390,12 +3438,9 @@ static smf_mbs_sess_t *smf_mbs_sess_add(void)
     return smf_mbs_sess;
 }
 
-static void smf_mbs_sess_remove(smf_mbs_sess_t *smf_mbs_sess)
+static void smf_mbs_sess_free(smf_mbs_sess_t *smf_mbs_sess)
 {
-    ogs_assert(smf_mbs_sess);
-
-    ogs_list_remove(&self.smf_mbs_sess_list, smf_mbs_sess);
-    ogs_pfcp_sess_clear(&smf_mbs_sess->pfcp);
+    if (!smf_mbs_sess) return;
 
     if (smf_mbs_sess->mbs_session_ref)
         ogs_free(smf_mbs_sess->mbs_session_ref);
@@ -3403,10 +3448,9 @@ static void smf_mbs_sess_remove(smf_mbs_sess_t *smf_mbs_sess)
     if (smf_mbs_sess->service_type)
         ogs_free(smf_mbs_sess->service_type);
 
-    // TMGI is allocated/freed separately
+    // TMGI is allocated/freed separately but we need to tidy up the index hash
 
     if (smf_mbs_sess->mbs_session_id.is_ssm) {
-        ogs_hash_set(self.smf_mbs_sess_by_ssm, ((char*)smf_mbs_sess->mbs_session_id.ssm)+sizeof(ogs_lnode_t), sizeof(*smf_mbs_sess->mbs_session_id.ssm)-sizeof(ogs_lnode_t), NULL);
         ogs_free(smf_mbs_sess->mbs_session_id.ssm);
     }
 
@@ -3430,7 +3474,28 @@ static void smf_mbs_sess_remove(smf_mbs_sess_t *smf_mbs_sess)
 
     ogs_pool_free(&smf_n4_seid_pool, smf_mbs_sess->smf_n4mb_seid_node);
 
+    ogs_mbs_service_area_free(smf_mbs_sess->mbs_service_area);
+    ogs_ext_mbs_service_area_free(smf_mbs_sess->ext_mbs_service_area);
+
     ogs_pool_id_free(&smf_mbs_sess_pool, smf_mbs_sess);
+}
+
+static void smf_mbs_sess_remove(smf_mbs_sess_t *smf_mbs_sess)
+{
+    ogs_assert(smf_mbs_sess);
+
+    ogs_list_remove(&self.smf_mbs_sess_list, smf_mbs_sess);
+    ogs_pfcp_sess_clear(&smf_mbs_sess->pfcp);
+
+    if (smf_mbs_sess->mbs_session_id.is_tmgi) {
+        smf_mbs_sessions_by_tmgi_remove_mbs_sess(smf_mbs_sess);
+    }
+
+    if (smf_mbs_sess->mbs_session_id.is_ssm) {
+        smf_mbs_sessions_by_ssm_remove_mbs_sess(smf_mbs_sess);
+    }
+
+    smf_mbs_sess_free(smf_mbs_sess);
 
     ogs_info("[Removed] Number of MBS Sessions in SMF is now %d",
             ogs_list_count(&self.smf_mbs_sess_list));
@@ -3463,7 +3528,6 @@ smf_mbs_sess_t *smf_mbs_sess_create(ogs_tmgi_t *tmgi, ogs_ssm_t *ssm, char *serv
     if (ogs_strcasecmp(smf_mbs_sess->service_type, "BROADCAST") == 0) {
         smf_mbs_sess->mbs_session_id.tmgi = tmgi;
         smf_mbs_sess->mbs_session_id.is_tmgi = 1;
-
         if (ssm)
             smf_mbs_sess->ssm = ssm;
     } else if (ogs_strcasecmp(smf_mbs_sess->service_type, "MULTICAST") == 0) {
@@ -3475,7 +3539,6 @@ smf_mbs_sess_t *smf_mbs_sess_create(ogs_tmgi_t *tmgi, ogs_ssm_t *ssm, char *serv
             if (!ssm->dest_ip_addr.ipv4) memset(&ssm->dest_ip_addr.addr, 0, sizeof(ssm->dest_ip_addr.addr));
             if (!ssm->dest_ip_addr.ipv6) memset(ssm->dest_ip_addr.addr6, 0, sizeof(ssm->dest_ip_addr.addr6));
             ssm->dest_ip_addr.reserved = 0;
-            ogs_hash_set(self.smf_mbs_sess_by_ssm, ((char*)ssm) + sizeof(ogs_lnode_t), sizeof(*ssm)-sizeof(ogs_lnode_t), smf_mbs_sess);
             smf_mbs_sess->mbs_session_id.ssm = ssm;
             smf_mbs_sess->mbs_session_id.is_ssm = 1;
 
@@ -3485,6 +3548,17 @@ smf_mbs_sess_t *smf_mbs_sess_create(ogs_tmgi_t *tmgi, ogs_ssm_t *ssm, char *serv
             smf_mbs_sess->mbs_session_id.is_tmgi = 1;
         }
         smf_mbs_sess->state = smf_mbs_sess_multicast_state_configured;
+    }
+
+    if (smf_context_have_matching_mbs_session_id(smf_mbs_sess)) {
+	ogs_debug("New MBS Session collides with an existing MBS Session, aborting create");
+        smf_mbs_sess_free(smf_mbs_sess);
+        smf_mbs_sess = NULL;
+    } else {
+        if (smf_mbs_sess->mbs_session_id.is_tmgi)
+            smf_mbs_sessions_by_tmgi_add_mbs_sess(smf_mbs_sess);
+        if (smf_mbs_sess->mbs_session_id.is_ssm)
+            smf_mbs_sessions_by_ssm_add_mbs_sess(smf_mbs_sess);
     }
 
     return smf_mbs_sess;
@@ -3514,102 +3588,6 @@ void smf_mbs_sess_release(smf_mbs_sess_t *smf_mbs_sess)
 smf_mbs_sess_t *smf_mbs_sess_find_by_seid(uint64_t seid)
 {
     return ogs_hash_get(self.smf_n4_seid_hash, &seid, sizeof(seid));
-}
-
-#if 0
-#define OGS_SSM_MAX_STRING_LENGTH (INET6_ADDRSTRLEN*2 + 4)
-
-static char *ogs_ssm_string(const ogs_ssm_t *ssm, char *buffer)
-{
-    if (!ssm) {
-        strcpy(buffer, "<null>");
-    } else {
-        if (ssm->src_ip_addr.ipv4) {
-            char addr[INET_ADDRSTRLEN];
-            sprintf(buffer, "%s:", inet_ntop(AF_INET, &ssm->src_ip_addr.addr, addr, INET_ADDRSTRLEN));
-        } else if (ssm->src_ip_addr.ipv6) {
-            char addr[INET6_ADDRSTRLEN];
-            sprintf(buffer, "[%s]:", inet_ntop(AF_INET6, ssm->src_ip_addr.addr6, addr, INET6_ADDRSTRLEN));
-        } else {
-            strcpy(buffer, "*:");
-        }
-        char *rest = buffer + strlen(buffer);
-        if (ssm->dest_ip_addr.ipv4) {
-            char addr[INET_ADDRSTRLEN];
-            strcpy(rest, inet_ntop(AF_INET, &ssm->dest_ip_addr.addr, addr, INET_ADDRSTRLEN));
-        } else if (ssm->dest_ip_addr.ipv6) {
-            char addr[INET6_ADDRSTRLEN];
-            strcpy(rest, inet_ntop(AF_INET6, ssm->dest_ip_addr.addr6, addr, INET6_ADDRSTRLEN));
-        } else {
-            strcpy(rest, "*");
-        }
-    }
-    return buffer;
-}
-
-static int _dump_ssm_keys(void *rec, const void *key, int klen, const void *value)
-{
-    const ogs_ssm_t *ssm = (const ogs_ssm_t *)(((const char*)key)-sizeof(ogs_lnode_t));
-    const ogs_ssm_t *ssm2 = (const ogs_ssm_t *)(((const char*)rec)-sizeof(ogs_lnode_t));
-    char buffer[OGS_SSM_MAX_STRING_LENGTH];
-    char buffer2[OGS_SSM_MAX_STRING_LENGTH];
-
-    char *diff = NULL;
-    size_t i;
-    for (i = 0; i < sizeof(ogs_ssm_t) - sizeof(ogs_lnode_t); i++) {
-        if (((char*)rec)[i] != ((const char*)key)[i]) {
-            if (!diff) {
-                diff = ogs_msprintf("differs at bytes: %zu", i);
-            } else {
-                diff = ogs_mstrcatf(diff, ", %zu", i);
-            }
-        }
-    }
-    if (!diff) diff = ogs_strdup("same");
-
-    ogs_debug(" (%p) %s == %s : %s", value, ogs_ssm_string(ssm, buffer), ogs_ssm_string(ssm2, buffer2), diff);
-    ogs_free(diff);
-    return 1;
-}
-#endif
-
-smf_mbs_sess_t *smf_mbs_sess_find_by_ssm(ogs_ssm_t *ssm)
-{
-    if (!ssm) return NULL;
-
-    /* sanitize SSM for comparison */
-    ogs_ssm_t tmp;
-    memset(&tmp, 0, sizeof(tmp));
-    if (ssm->src_ip_addr.ipv4) {
-        tmp.src_ip_addr.ipv4 = 1;
-        tmp.src_ip_addr.addr = ssm->src_ip_addr.addr;
-    }
-    if (ssm->src_ip_addr.ipv6) {
-        tmp.src_ip_addr.ipv6 = 1;
-        memcpy(tmp.src_ip_addr.addr6, ssm->src_ip_addr.addr6, sizeof(tmp.src_ip_addr.addr6));
-    }
-    tmp.src_ip_addr.len = ssm->src_ip_addr.len;
-    if (ssm->dest_ip_addr.ipv4) {
-        tmp.dest_ip_addr.ipv4 = 1;
-        tmp.dest_ip_addr.addr = ssm->dest_ip_addr.addr;
-    }
-    if (ssm->dest_ip_addr.ipv6) {
-        tmp.dest_ip_addr.ipv6 = 1;
-        memcpy(tmp.dest_ip_addr.addr6, ssm->dest_ip_addr.addr6, sizeof(tmp.dest_ip_addr.addr6));
-    }
-    tmp.dest_ip_addr.len = ssm->dest_ip_addr.len;
-
-#if 0
-    char buffer[OGS_SSM_MAX_STRING_LENGTH];
-    ogs_debug("Search for MBS Session with SSM = %s", ogs_ssm_string(&tmp, buffer));
-
-    ogs_hash_do(_dump_ssm_keys, ((char*)&tmp) + sizeof(ogs_lnode_t), self.smf_mbs_sess_by_ssm);
-#endif
-
-    smf_mbs_sess_t *ret = ogs_hash_get(self.smf_mbs_sess_by_ssm, ((char*)&tmp) + sizeof(ogs_lnode_t), sizeof(tmp) - sizeof(ogs_lnode_t));
-    ogs_debug("Found MBS Session %p", ret);
-
-    return ret;
 }
 
 // TODO (borieher): Select UPF based on MBS parameters
@@ -3721,4 +3699,246 @@ void smf_mbs_sess_create_mbs_data_forwarding(smf_mbs_sess_t *mbs_sess)
     //dl_far->outer_header_creation.gtpu4 = 1;
     dl_far->outer_header_creation.ssm_c_teid = 1;
     dl_far->outer_header_creation_len = 6;
+}
+
+static int smf_mbs_sess_list_delete_hash_entry(void *rec, const void *key, int klen, const void *value)
+{
+    ogs_hash_t *mbs_sess_list_hash = (ogs_hash_t*)rec;
+    ogs_list_t *mbs_sess_list = (ogs_list_t*)value;
+    smf_mbs_sess_lnode_t *lnode;
+    smf_mbs_sess_lnode_t *next;
+
+    ogs_hash_set(mbs_sess_list_hash, key, klen, NULL);
+
+    ogs_list_for_each_safe(mbs_sess_list, next, lnode) {
+        ogs_list_remove(mbs_sess_list, lnode);
+        ogs_free(lnode);
+    }
+
+    ogs_free(mbs_sess_list);
+
+    return 1;
+}
+
+static void smf_mbs_sess_list_hash_destroy(ogs_hash_t *mbs_sess_list_hash)
+{
+    ogs_assert(mbs_sess_list_hash);
+    ogs_hash_do(smf_mbs_sess_list_delete_hash_entry, mbs_sess_list_hash, mbs_sess_list_hash);
+    ogs_hash_destroy(mbs_sess_list_hash);
+}
+
+static void smf_mbs_sessions_by_tmgi_add_mbs_sess(smf_mbs_sess_t *mbs_sess)
+{
+    int klen;
+    void *key;
+
+    if (mbs_sess && mbs_sess->mbs_session_id.is_tmgi) {
+	key = smf_mbs_sessions_by_tmgi_key(mbs_sess->mbs_session_id.tmgi, &klen);
+        ogs_list_t *mbs_sess_list = (ogs_list_t*)ogs_hash_get(self.smf_mbs_sessions_by_tmgi, key, klen);
+        if (!mbs_sess_list) {
+            mbs_sess_list = (ogs_list_t*)ogs_calloc(1, sizeof(ogs_list_t));
+            ogs_assert(mbs_sess_list);
+            ogs_hash_set(self.smf_mbs_sessions_by_tmgi, key, klen, mbs_sess_list);
+        }
+        smf_mbs_sess_lnode_t *lnode = (smf_mbs_sess_lnode_t*)ogs_calloc(1, sizeof(smf_mbs_sess_lnode_t));
+        lnode->mbs_session = mbs_sess;
+        ogs_list_add(mbs_sess_list, lnode);
+    }
+}
+
+static void smf_mbs_sessions_by_tmgi_remove_mbs_sess(smf_mbs_sess_t *mbs_sess)
+{
+    int klen;
+    void *key;
+
+    if (mbs_sess && mbs_sess->mbs_session_id.is_tmgi) {
+        key = smf_mbs_sessions_by_tmgi_key(mbs_sess->mbs_session_id.tmgi, &klen);
+        ogs_list_t *mbs_sess_list = (ogs_list_t*)ogs_hash_get(self.smf_mbs_sessions_by_tmgi, key, klen);
+        if (mbs_sess_list) {
+            smf_mbs_sess_lnode_t *next;
+            smf_mbs_sess_lnode_t *lnode;
+            ogs_list_for_each_safe(mbs_sess_list, next, lnode) {
+                if (lnode->mbs_session == mbs_sess) {
+                    ogs_list_remove(mbs_sess_list, lnode);
+                    ogs_free(lnode);
+                    break;
+                }
+            }
+            if (ogs_list_count(mbs_sess_list) == 0) {
+                ogs_hash_set(self.smf_mbs_sessions_by_tmgi, key, klen, NULL);
+                ogs_free(mbs_sess_list);
+            }
+        }
+    }
+}
+
+static void *smf_mbs_sessions_by_tmgi_key(ogs_tmgi_t *tmgi, int *klen)
+{
+    if (!tmgi) {
+        *klen = 0;
+        return NULL;
+    }
+
+    *klen = sizeof(ogs_tmgi_t) - sizeof(ogs_lnode_t);
+    return (void*)(((char*)tmgi) + sizeof(ogs_lnode_t));
+}
+
+static void smf_mbs_sessions_by_ssm_add_mbs_sess(smf_mbs_sess_t *mbs_sess)
+{
+    int klen;
+    void *key;
+
+    if (mbs_sess && mbs_sess->mbs_session_id.is_ssm) {
+        key = smf_mbs_sessions_by_ssm_key(mbs_sess->mbs_session_id.ssm, &klen);
+        ogs_list_t *mbs_sess_list = (ogs_list_t*)ogs_hash_get(self.smf_mbs_sessions_by_ssm, key, klen);
+        if (!mbs_sess_list) {
+            mbs_sess_list = (ogs_list_t*)ogs_calloc(1, sizeof(ogs_list_t));
+            ogs_assert(mbs_sess_list);
+            ogs_hash_set(self.smf_mbs_sessions_by_ssm, key, klen, mbs_sess_list);
+        }
+        smf_mbs_sess_lnode_t *lnode = (smf_mbs_sess_lnode_t*)ogs_calloc(1, sizeof(smf_mbs_sess_lnode_t));
+        lnode->mbs_session = mbs_sess;
+        ogs_list_add(mbs_sess_list, lnode);
+    }
+}
+
+static void smf_mbs_sessions_by_ssm_remove_mbs_sess(smf_mbs_sess_t *mbs_sess)
+{
+    int klen;
+    void *key;
+
+    if (mbs_sess && mbs_sess->mbs_session_id.is_ssm) {
+        key = smf_mbs_sessions_by_ssm_key(mbs_sess->mbs_session_id.ssm, &klen);
+        ogs_list_t *mbs_sess_list = (ogs_list_t*)ogs_hash_get(self.smf_mbs_sessions_by_ssm, key, klen);
+        if (mbs_sess_list) {
+            smf_mbs_sess_lnode_t *next;
+            smf_mbs_sess_lnode_t *lnode;
+            ogs_list_for_each_safe(mbs_sess_list, next, lnode) {
+                if (lnode->mbs_session == mbs_sess) {
+                    ogs_list_remove(mbs_sess_list, lnode);
+                    ogs_free(lnode);
+                    break;
+                }
+            }
+            if (ogs_list_count(mbs_sess_list) == 0) {
+                ogs_hash_set(self.smf_mbs_sessions_by_ssm, key, klen, NULL);
+                ogs_free(mbs_sess_list);
+            }
+        }
+    }
+}
+
+static void *smf_mbs_sessions_by_ssm_key(ogs_ssm_t *ssm, int *klen)
+{
+    if (!ssm) {
+        *klen = 0;
+        return NULL;
+    }
+
+    *klen = sizeof(ogs_ssm_t) - sizeof(ogs_lnode_t);
+    return (void*)(((char*)ssm) + sizeof(ogs_lnode_t));
+}
+
+static bool smf_mbs_sess_list_service_areas_overlap(ogs_list_t *mbs_sess_list, smf_mbs_sess_t *mbs_session)
+{
+    smf_mbs_sess_lnode_t *node;
+
+    if (!mbs_sess_list || !mbs_session) return false;
+    if (!mbs_session->mbs_service_area && !mbs_session->ext_mbs_service_area) return true;
+
+    ogs_list_for_each(mbs_sess_list, node) {
+        if (smf_mbs_sess_service_areas_overlap(node->mbs_session, mbs_session)) return true;
+    }
+
+    return false;
+}
+
+static bool smf_mbs_sess_service_areas_overlap(smf_mbs_sess_t *a, smf_mbs_sess_t *b)
+{
+    // If either MBS Session is for the global Service Area, then there's an overlap.
+    if (!a->mbs_service_area && !a->ext_mbs_service_area) return true;
+    // if (!b->mbs_service_area && !b->ext_mbs_service_area) return true; // Already tested
+
+    if (a->mbs_service_area && b->mbs_service_area) {
+        // check MBS Service Areas overlap
+        if (a->mbs_service_area->ncgi_tai_list) {
+            ogs_ncgi_tai_t *a_ncgi_tai;
+            ogs_list_for_each(a->mbs_service_area->ncgi_tai_list, a_ncgi_tai) {
+                if (b->mbs_service_area->ncgi_tai_list) {
+                    ogs_ncgi_tai_t *b_ncgi_tai;
+                    ogs_list_for_each(b->mbs_service_area->ncgi_tai_list, b_ncgi_tai) {
+                        if (smf_tai_equal(&a_ncgi_tai->tai, &b_ncgi_tai->tai)) {
+                            ogs_ncgi_t *a_ncgi;
+                            ogs_list_for_each(&a_ncgi_tai->cell_list, a_ncgi) {
+                                ogs_ncgi_t *b_ncgi;
+                                ogs_list_for_each(&b_ncgi_tai->cell_list, b_ncgi) {
+                                    if (smf_ncgi_equal(a_ncgi, b_ncgi)) return true;
+                                }
+                            }
+                        }
+                    }
+                }
+                if (b->mbs_service_area->tai_list) {
+                    ogs_tai_t *b_tai;
+                    ogs_list_for_each(b->mbs_service_area->tai_list, b_tai) {
+                        if (smf_tai_equal(&a_ncgi_tai->tai, b_tai)) return true;
+                    }
+                }
+            }
+        }
+        if (a->mbs_service_area->tai_list) {
+            ogs_tai_t *a_tai;
+            ogs_list_for_each(a->mbs_service_area->tai_list, a_tai) {
+                if (b->mbs_service_area->ncgi_tai_list) {
+                    ogs_ncgi_tai_t *b_ncgi_tai;
+                    ogs_list_for_each(b->mbs_service_area->ncgi_tai_list, b_ncgi_tai) {
+                        if (smf_tai_equal(a_tai, &b_ncgi_tai->tai)) return true;
+                    }
+                }
+                if (b->mbs_service_area->tai_list) {
+                    ogs_tai_t *b_tai;
+                    ogs_list_for_each(b->mbs_service_area->tai_list, b_tai) {
+                        if (smf_tai_equal(a_tai, b_tai)) return true;
+                    }
+                }
+            }
+        }
+    }
+
+    if (a->ext_mbs_service_area && b->ext_mbs_service_area) {
+        // TODO: check External MBS Service Areas overlap
+        ogs_warn("smf_mbs_sess_service_areas_overlap: External MBS Service Area comparison not implemented yet!");
+    }
+
+    return false;
+}
+
+static bool smf_tai_equal(const ogs_tai_t *a, const ogs_tai_t *b)
+{
+    if (!a && !b) return true;
+    if (!a || !b) return false;
+    if (ogs_plmn_id_mcc(&a->plmn_id) == ogs_plmn_id_mcc(&b->plmn_id) &&
+        ogs_plmn_id_mnc(&a->plmn_id) == ogs_plmn_id_mnc(&b->plmn_id)) {
+        if (strcmp(a->tac, b->tac) == 0) {
+            if (!a->nid && !b->nid) return true;
+            if (!a->nid || !b->nid) return false;
+            return (strcmp(a->nid, b->nid) == 0);
+        }
+    }
+    return false;
+}
+
+static bool smf_ncgi_equal(const ogs_ncgi_t *a, const ogs_ncgi_t *b)
+{
+    if (!a && !b) return true;
+    if (!a || !b) return false;
+    if (ogs_plmn_id_mcc(&a->plmn_id) == ogs_plmn_id_mcc(&b->plmn_id) &&
+        ogs_plmn_id_mnc(&a->plmn_id) == ogs_plmn_id_mnc(&b->plmn_id)) {
+        if (strcmp(a->nr_cell_id, b->nr_cell_id) == 0) {
+            if (!a->nid && !b->nid) return true;
+            if (!a->nid || !b->nid) return false;
+            return (strcmp(a->nid, b->nid) == 0);
+        }
+    }
+    return false;
 }

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -68,6 +68,13 @@ typedef struct smf_ctf_config_s {
 
 int smf_ctf_config_init(smf_ctf_config_t *ctf_config);
 
+typedef struct smf_mbs_sess_s smf_mbs_sess_t;
+
+typedef struct smf_mbs_sess_lnode_s {
+    ogs_lnode_t     node;
+    smf_mbs_sess_t *mbs_session; // weak link, not freed with node
+} smf_mbs_sess_lnode_t;
+
 typedef struct smf_context_s {
     smf_ctf_config_t    ctf_config;
     const char*         diam_conf_path;   /* SMF Diameter conf path */
@@ -94,7 +101,8 @@ typedef struct smf_context_s {
     ogs_hash_t      *ipv6_hash;     /* hash table (IPv6 Address) */
     ogs_hash_t      *smf_n4_seid_hash; /* hash table (SMF-N4-SEID) */
     ogs_hash_t      *n1n2message_hash; /* hash table (N1N2Message Location) */
-    ogs_hash_t	    *smf_mbs_sess_by_ssm; /* hash table of SSM => multicast MBS Session (weak link) */
+    ogs_hash_t	    *smf_mbs_sessions_by_ssm; /* hash table of SSM => ogs_list_t of smf_mbs_sess_lnode_t items */
+    ogs_hash_t      *smf_mbs_sessions_by_tmgi; /* hash table of TMGI => ogs_list_t of smf_mbs_sess_lnode_t items */
 
     uint16_t        mtu;            /* MTU to advertise in PCO */
 
@@ -109,8 +117,8 @@ typedef struct smf_context_s {
      ((__sMF) && (ogs_list_count(&(__sMF)->sess_list)) == 1)
     ogs_list_t      smf_ue_list;
 
-    ogs_list_t      tmgi_list;
-    ogs_list_t      smf_mbs_sess_list;
+    ogs_list_t      tmgi_list;         /* list of ogs_tmgi_t */
+    ogs_list_t      smf_mbs_sess_list; /* list of smf_mbs_sess_t */
 } smf_context_t;
 
 typedef struct smf_gtp_node_s {
@@ -557,6 +565,9 @@ typedef struct smf_mbs_sess_s {
     bool ingress_tun_addr_req;
     ogs_sockaddr_t *ingress_tun_addr;
 
+    /* Service Areas */
+    ogs_mbs_service_area_t *mbs_service_area;
+    ogs_ext_mbs_service_area_t *ext_mbs_service_area;
 } smf_mbs_sess_t;
 
 // NOTE (borieher): Not defined in the specs, default to 2 extra hours
@@ -683,9 +694,10 @@ void smf_mbs_sess_release(smf_mbs_sess_t *smf_mbs_sess);
 smf_mbs_sess_t *smf_mbs_sess_find_by_id(ogs_pool_id_t id);
 smf_mbs_sess_t *smf_mbs_sess_find_by_mbs_session_ref(char *mbs_session_ref);
 smf_mbs_sess_t *smf_mbs_sess_find_by_seid(uint64_t seid);
-smf_mbs_sess_t *smf_mbs_sess_find_by_ssm(ogs_ssm_t *ssm);
 void smf_mbs_sess_select_upf(smf_mbs_sess_t *mbs_sess);
 void smf_mbs_sess_create_mbs_data_forwarding(smf_mbs_sess_t *mbs_sess);
+
+bool smf_context_have_matching_mbs_session_id(smf_mbs_sess_t *mbs_session);
 
 #ifdef __cplusplus
 }

--- a/src/smf/nmbsmf-handler.c
+++ b/src/smf/nmbsmf-handler.c
@@ -18,9 +18,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "ogs-proto.h"
+
 #include "sbi-path.h"
 #include "pfcp-path.h"
 #include "nmbsmf-handler.h"
+
+static bool smf_nmbsmf_parse_tai(ogs_sbi_stream_t *stream, ogs_sbi_message_t *message, ogs_tai_t *tai, OpenAPI_tai_t *api_tai);
+static bool smf_nmbsmf_parse_ncgi(ogs_sbi_stream_t *stream, ogs_sbi_message_t *message, ogs_ncgi_t *ncgi, OpenAPI_ncgi_t *api_ncgi);
+static bool smf_nmbsmf_parse_geographic_area(ogs_sbi_stream_t *stream, ogs_sbi_message_t *message, ogs_geographic_area_t *geog_area,
+                                            OpenAPI_geographic_area_t *api_geog_area);
+static bool smf_nmbsmf_parse_civic_address(ogs_sbi_stream_t *stream, ogs_sbi_message_t *message, ogs_civic_address_t *civic_addr,
+                                            OpenAPI_civic_address_t *api_civic_addr);
 
 /* Nmbsmf_TMGI Service API */
 
@@ -299,6 +308,13 @@ bool smf_nmbsmf_handle_mbs_session_create(
     ogs_tmgi_t *tmgi = NULL;
     ogs_ssm_t *ssm = NULL;
     smf_mbs_sess_t *mbs_sess = NULL;
+    ogs_mbs_service_area_t *mbs_service_area = NULL;
+    ogs_ext_mbs_service_area_t *ext_mbs_service_area = NULL;
+    ogs_ncgi_t *ncgi = NULL;
+    ogs_tai_t *tai = NULL;
+    ogs_ncgi_tai_t *ncgi_tai = NULL;
+    ogs_geographic_area_t *geog_area = NULL;
+    ogs_civic_address_t *civic_addr = NULL;
 
     ogs_assert(stream);
     ogs_assert(message);
@@ -370,14 +386,6 @@ bool smf_nmbsmf_handle_mbs_session_create(
         ssm = ogs_malloc(sizeof(*ssm));
         ogs_assert(ssm);
         ogs_sbi_parse_ssm(ssm, CreateReqData->mbs_session->ssm);
-    }
-    if (ssm && is_multicast_service && smf_mbs_sess_find_by_ssm(ssm)) {
-         ogs_error("MBS Session Create: SSM already used");
-         ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_FORBIDDEN,
-                        message, "Forbidden", "MBS Session Create failed, SSM in [mbsSessionId] has already been used",
-                        NMBSMF_MBSSESSION_MBS_SESSION_ALREADY_CREATED);
-         rv = OGS_ERROR;
-         goto cleanup;
     }
 
     // Perform the TMGI allocate operation
@@ -469,16 +477,122 @@ bool smf_nmbsmf_handle_mbs_session_create(
         }
     }
 
+    // Extract MBS Service Area if present
+    if (CreateReqData->mbs_session->mbs_service_area) {
+        if (CreateReqData->mbs_session->mbs_service_area->ncgi_list) {
+            OpenAPI_lnode_t *node;
+            OpenAPI_list_for_each(CreateReqData->mbs_session->mbs_service_area->ncgi_list, node) {
+                OpenAPI_lnode_t *cell_node;
+                if (!mbs_service_area) mbs_service_area = (__typeof__(mbs_service_area))ogs_calloc(1, sizeof(*mbs_service_area));
+                if (!mbs_service_area->ncgi_tai_list)
+                    mbs_service_area->ncgi_tai_list =
+                            (__typeof__(mbs_service_area->ncgi_tai_list))ogs_calloc(1, sizeof(*mbs_service_area->ncgi_tai_list));
+                OpenAPI_ncgi_tai_t *api_ncgi_tai = (OpenAPI_ncgi_tai_t*)node->data;
+                ncgi_tai = (ogs_ncgi_tai_t*)ogs_calloc(1, sizeof(*ncgi_tai));
+                if (!smf_nmbsmf_parse_tai(stream, message, &ncgi_tai->tai, api_ncgi_tai->tai)) {
+                    rv = OGS_ERROR;
+                    goto cleanup;
+                }
+                OpenAPI_list_for_each(api_ncgi_tai->cell_list, cell_node) {
+                    OpenAPI_ncgi_t *api_ncgi = (OpenAPI_ncgi_t*)node->data;
+                    ncgi = (ogs_ncgi_t*)ogs_calloc(1, sizeof(*ncgi));
+                    if (!smf_nmbsmf_parse_ncgi(stream, message, ncgi, api_ncgi)) {
+                        rv = OGS_ERROR;
+                        goto cleanup;
+                    }
+                    ogs_list_add(&ncgi_tai->cell_list, ncgi);
+                    ncgi = NULL;
+                }
+                ogs_list_add(mbs_service_area->ncgi_tai_list, ncgi_tai);
+                ncgi_tai = NULL;
+            }
+        }
+        if (CreateReqData->mbs_session->mbs_service_area->tai_list) {
+            OpenAPI_lnode_t *node;
+            OpenAPI_list_for_each(CreateReqData->mbs_session->mbs_service_area->tai_list, node) {
+                if (!mbs_service_area) mbs_service_area = (__typeof__(mbs_service_area))ogs_calloc(1, sizeof(*mbs_service_area));
+                if (!mbs_service_area->tai_list)
+                    mbs_service_area->tai_list =
+                            (__typeof__(mbs_service_area->tai_list))ogs_calloc(1, sizeof(*mbs_service_area->tai_list));
+                OpenAPI_tai_t *api_tai = (OpenAPI_tai_t*)node->data;
+                tai = (ogs_tai_t*)ogs_calloc(1, sizeof(*tai));
+                if (!smf_nmbsmf_parse_tai(stream, message, tai, api_tai)) {
+                    rv = OGS_ERROR;
+                    goto cleanup;
+                }
+                ogs_list_add(mbs_service_area->tai_list, tai);
+                tai = NULL;
+            }
+        }
+    }
+
+    // Extract External MBS Service Area if present
+    if (CreateReqData->mbs_session->ext_mbs_service_area) {
+        if (CreateReqData->mbs_session->ext_mbs_service_area->geographic_area_list) {
+            OpenAPI_lnode_t *node;
+            OpenAPI_list_for_each(CreateReqData->mbs_session->ext_mbs_service_area->geographic_area_list, node) {
+                if (!ext_mbs_service_area)
+                    ext_mbs_service_area = (__typeof__(ext_mbs_service_area))ogs_calloc(1, sizeof(*ext_mbs_service_area));
+                if (!ext_mbs_service_area->geographic_area_list)
+                    ext_mbs_service_area->geographic_area_list =
+                            (__typeof__(ext_mbs_service_area->geographic_area_list))ogs_calloc(1,
+                                        sizeof(*ext_mbs_service_area->geographic_area_list));
+                OpenAPI_geographic_area_t *api_geog_area = (OpenAPI_geographic_area_t*)node->data;
+                geog_area = (ogs_geographic_area_t*)ogs_calloc(1, sizeof(*geog_area));
+                if (!smf_nmbsmf_parse_geographic_area(stream, message, geog_area, api_geog_area)) {
+                    rv = OGS_ERROR;
+                    goto cleanup;
+                }
+                ogs_list_add(ext_mbs_service_area->geographic_area_list, geog_area);
+                geog_area = NULL;
+            }
+        }
+        if (CreateReqData->mbs_session->ext_mbs_service_area->civic_address_list) {
+            OpenAPI_lnode_t *node;
+            OpenAPI_list_for_each(CreateReqData->mbs_session->ext_mbs_service_area->civic_address_list, node) {
+                if (!ext_mbs_service_area)
+                    ext_mbs_service_area = (__typeof__(ext_mbs_service_area))ogs_calloc(1, sizeof(*ext_mbs_service_area));
+                if (!ext_mbs_service_area->civic_address_list)
+                    ext_mbs_service_area->civic_address_list =
+                            (__typeof__(ext_mbs_service_area->civic_address_list))ogs_calloc(1,
+                                        sizeof(*ext_mbs_service_area->civic_address_list));
+                OpenAPI_civic_address_t *api_civic_addr = (OpenAPI_civic_address_t*)node->data;
+                civic_addr = (ogs_civic_address_t*)ogs_calloc(1, sizeof(*civic_addr));
+                if (!smf_nmbsmf_parse_civic_address(stream, message, civic_addr, api_civic_addr)) {
+                    rv = OGS_ERROR;
+                    goto cleanup;
+                }
+                ogs_list_add(ext_mbs_service_area->civic_address_list, civic_addr);
+                civic_addr = NULL;
+            }
+        }
+    }
+
     // TODO (borieher): Check provided TMGI is not added to an existing MBS Session
 
     // MBS Session create
     mbs_sess = smf_mbs_sess_create(tmgi, ssm, service_type);
     ssm = NULL; // ssm passed to mbs_sess
+
+    if (!mbs_sess) {
+        ogs_error("MBS Session Create: MBS Session Id collides with existing MBS Session");
+        ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_FORBIDDEN,
+                        message, "Forbidden", "MBS Session Create failed, [mbsSessionId] has already been used in the same area",
+                        NMBSMF_MBSSESSION_MBS_SESSION_ALREADY_CREATED);
+        rv = OGS_ERROR;
+        goto cleanup;
+    }
+
     mbs_sess->ingress_tun_addr_req = (CreateReqData->mbs_session->is_ingress_tun_addr_req &&
                                       CreateReqData->mbs_session->ingress_tun_addr_req != 0);
 
+    mbs_sess->mbs_service_area = mbs_service_area;
+    mbs_service_area = NULL;
+    mbs_sess->ext_mbs_service_area = ext_mbs_service_area;
+    ext_mbs_service_area = NULL;
+
     if (is_multicast_service) {
-	mbs_sess->activity_status = CreateReqData->mbs_session->activity_status;
+        mbs_sess->activity_status = CreateReqData->mbs_session->activity_status;
     }
 
     /*********************************************************************
@@ -490,6 +604,27 @@ bool smf_nmbsmf_handle_mbs_session_create(
     smf_5gc_pfcp_n4mb_send_session_establishment_request(mbs_sess, 0, stream);
 
 cleanup:
+    if (mbs_service_area)
+        ogs_mbs_service_area_free(mbs_service_area);
+
+    if (ext_mbs_service_area)
+        ogs_ext_mbs_service_area_free(ext_mbs_service_area);
+
+    if (ncgi)
+        ogs_ncgi_free(ncgi);
+
+    if (tai)
+        ogs_tai_free(tai);
+
+    if (ncgi_tai)
+        ogs_ncgi_tai_free(ncgi_tai);
+
+    if (geog_area)
+        ogs_geographic_area_free(geog_area);
+
+    if (civic_addr)
+        ogs_civic_address_free(civic_addr);
+
     if (expiration_time)
         ogs_free(expiration_time);
 
@@ -586,10 +721,10 @@ bool smf_nmbsmf_handle_mbs_session_patch(smf_mbs_sess_t *mbs_sess,
         }
         SWITCH(patch_item->path)
         CASE("/activityStatus")
-	    if (strcmp(mbs_sess->service_type, "MULTICAST")) {
-		ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_FORBIDDEN, message, "Update forbidden",
+            if (strcmp(mbs_sess->service_type, "MULTICAST")) {
+                ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_FORBIDDEN, message, "Update forbidden",
                         "Requested MBS Session Update failed, activityStatus can only be updated for multicast services",
-			"MODIFICATION_NOT_ALLOWED");
+                        "MODIFICATION_NOT_ALLOWED");
                 return false;
             }
             mbs_sess->activity_status = OpenAPI_mbs_session_activity_status_FromString(cJSON_GetStringValue(patch_item->value->json));
@@ -738,6 +873,89 @@ bool smf_nmbsmf_handle_mbs_session_patch(smf_mbs_sess_t *mbs_sess,
     ogs_assert(response);
 
     ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+
+    return true;
+}
+
+static bool smf_nmbsmf_parse_tai(ogs_sbi_stream_t *stream, ogs_sbi_message_t *message, ogs_tai_t *tai, OpenAPI_tai_t *api_tai)
+{
+    if (!ogs_sbi_parse_plmn_id(&tai->plmn_id, api_tai->plmn_id)) {
+        ogs_error("Parse TAI: Unable to parse the PLMN Id");
+        // bad plmn id, send error (400 + ERROR_INPUT_PARAMETERS)
+        ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+            message, "Bad PLMN Id", "MBS Session: TAI: Unable to parse the PLMN Id",
+            NMBSMF_MBSSESSION_ERROR_INPUT_PARAMETERS);
+        return false;
+    }
+    if (api_tai->tac) tai->tac = ogs_strdup(api_tai->tac);
+    if (api_tai->nid) tai->nid = ogs_strdup(api_tai->nid);
+    return true;
+}
+
+static bool smf_nmbsmf_parse_ncgi(ogs_sbi_stream_t *stream, ogs_sbi_message_t *message, ogs_ncgi_t *ncgi, OpenAPI_ncgi_t *api_ncgi)
+{
+    if (!ogs_sbi_parse_plmn_id(&ncgi->plmn_id, api_ncgi->plmn_id)) {
+        ogs_error("Parse NCGI: Unable to parse the PLMN Id");
+        // bad plmn id, send error (400 + ERROR_INPUT_PARAMETERS)
+        ogs_sbi_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST,
+            message, "Bad PLMN Id", "MBS Session: NCGI: Unable to parse the PLMN Id",
+            NMBSMF_MBSSESSION_ERROR_INPUT_PARAMETERS);
+        return false;
+    }
+    if (api_ncgi->nr_cell_id) ncgi->nr_cell_id = ogs_strdup(api_ncgi->nr_cell_id);
+    if (api_ncgi->nid) ncgi->nid = ogs_strdup(api_ncgi->nid);
+    return true;
+}
+
+static bool smf_nmbsmf_parse_civic_address(ogs_sbi_stream_t *stream, ogs_sbi_message_t *message, ogs_civic_address_t *civic_addr,
+                                            OpenAPI_civic_address_t *api_civic_addr)
+{
+    if (api_civic_addr->country) civic_addr->country = ogs_strdup(api_civic_addr->country);
+    if (api_civic_addr->a1) civic_addr->a[0] = ogs_strdup(api_civic_addr->a1);
+    if (api_civic_addr->a2) civic_addr->a[1] = ogs_strdup(api_civic_addr->a2);
+    if (api_civic_addr->a3) civic_addr->a[2] = ogs_strdup(api_civic_addr->a3);
+    if (api_civic_addr->a4) civic_addr->a[3] = ogs_strdup(api_civic_addr->a4);
+    if (api_civic_addr->a5) civic_addr->a[4] = ogs_strdup(api_civic_addr->a5);
+    if (api_civic_addr->a6) civic_addr->a[5] = ogs_strdup(api_civic_addr->a6);
+    if (api_civic_addr->prd) civic_addr->prd = ogs_strdup(api_civic_addr->prd);
+    if (api_civic_addr->pod) civic_addr->pod = ogs_strdup(api_civic_addr->pod);
+    if (api_civic_addr->sts) civic_addr->sts = ogs_strdup(api_civic_addr->sts);
+    if (api_civic_addr->hno) civic_addr->hno = ogs_strdup(api_civic_addr->hno);
+    if (api_civic_addr->hns) civic_addr->hns = ogs_strdup(api_civic_addr->hns);
+    if (api_civic_addr->lmk) civic_addr->lmk = ogs_strdup(api_civic_addr->lmk);
+    if (api_civic_addr->loc) civic_addr->loc = ogs_strdup(api_civic_addr->loc);
+    if (api_civic_addr->nam) civic_addr->nam = ogs_strdup(api_civic_addr->nam);
+    if (api_civic_addr->pc) civic_addr->pc = ogs_strdup(api_civic_addr->pc);
+    if (api_civic_addr->bld) civic_addr->bld = ogs_strdup(api_civic_addr->bld);
+    if (api_civic_addr->unit) civic_addr->unit = ogs_strdup(api_civic_addr->unit);
+    if (api_civic_addr->flr) civic_addr->flr = ogs_strdup(api_civic_addr->flr);
+    if (api_civic_addr->room) civic_addr->room = ogs_strdup(api_civic_addr->room);
+    if (api_civic_addr->plc) civic_addr->plc = ogs_strdup(api_civic_addr->plc);
+    if (api_civic_addr->pcn) civic_addr->pcn = ogs_strdup(api_civic_addr->pcn);
+    if (api_civic_addr->pobox) civic_addr->pobox = ogs_strdup(api_civic_addr->pobox);
+    if (api_civic_addr->addcode) civic_addr->addcode = ogs_strdup(api_civic_addr->addcode);
+    if (api_civic_addr->seat) civic_addr->seat = ogs_strdup(api_civic_addr->seat);
+    if (api_civic_addr->rd) civic_addr->rd = ogs_strdup(api_civic_addr->rd);
+    if (api_civic_addr->rdsec) civic_addr->rdsec = ogs_strdup(api_civic_addr->rdsec);
+    if (api_civic_addr->rdbr) civic_addr->rdbr = ogs_strdup(api_civic_addr->rdbr);
+    if (api_civic_addr->rdsubbr) civic_addr->rdsubbr = ogs_strdup(api_civic_addr->rdsubbr);
+    if (api_civic_addr->prm) civic_addr->prm = ogs_strdup(api_civic_addr->prm);
+    if (api_civic_addr->pom) civic_addr->pom = ogs_strdup(api_civic_addr->pom);
+    if (api_civic_addr->usage_rules) civic_addr->usage_rules = ogs_strdup(api_civic_addr->usage_rules);
+    if (api_civic_addr->method) civic_addr->method = ogs_strdup(api_civic_addr->method);
+    if (api_civic_addr->provided_by) civic_addr->provided_by = ogs_strdup(api_civic_addr->provided_by);
+
+    return true;
+}
+
+static bool smf_nmbsmf_parse_geographic_area(ogs_sbi_stream_t *stream, ogs_sbi_message_t *message, ogs_geographic_area_t *geog_area,
+                                            OpenAPI_geographic_area_t *api_geog_area)
+{
+    /* TODO (David Waring): OpenAPI type for geographic area is incomplete, so ignore until the templates are fixed */
+    /* For now just create a point at 0,0 */
+    geog_area->shape = ogs_supported_gad_shape_POINT;
+    geog_area->point.point.lon = 0.0;
+    geog_area->point.point.lat = 0.0;
 
     return true;
 }


### PR DESCRIPTION
This improves the duplicate MBS Session ID checks by also using the MBS Service Area and TMGI instead of just the SSM.

The External MBS Service Area is also used in the check but the implementation is incomplete due to the OpenAPI model in open5gs not supporting the *GeographicArea* type properly. Open5GS cannot parse the *GeographicArea* type properly making it impossible to use the `OpenAPI_geographic_area_t` automatically generated object type in API communications.

This is the MB-SMF implementation of the same rules introduced to the MBSF in PR 5G-MAG/rt-mbs-function#20.

Closes #22 