### PR TITLE
Bug-fix: Improve MBS Session ID comparison

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
        fuzz-seconds: 300
        output-sarif: true
    - name: Upload Crash
-     uses: actions/upload-artifact@v3
+     uses: actions/upload-artifact@v7
      if: failure() && steps.build.outcome == 'success'
      with:
        name: artifacts

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -3509,7 +3509,7 @@ static void smf_mbs_sess_remove_all(void)
         smf_mbs_sess_remove(smf_mbs_sess);
 }
 
-smf_mbs_sess_t *smf_mbs_sess_create(ogs_tmgi_t *tmgi, ogs_ssm_t *ssm, char *service_type)
+smf_mbs_sess_t *smf_mbs_sess_create(ogs_tmgi_t *tmgi, ogs_ssm_t *ssm, char *service_type, ogs_mbs_service_area_t *mbs_service_area, ogs_ext_mbs_service_area_t *ext_mbs_service_area)
 {
     smf_mbs_sess_t *smf_mbs_sess = NULL;
 
@@ -3517,13 +3517,16 @@ smf_mbs_sess_t *smf_mbs_sess_create(ogs_tmgi_t *tmgi, ogs_ssm_t *ssm, char *serv
     ogs_assert(service_type);
 
     if ((smf_mbs_sess = smf_mbs_sess_add()) == NULL) {
-        ogs_error("smf_mbs_sess_create() failed");
+        ogs_error("smf_mbs_sess_add() failed");
         return NULL;
     }
 
     smf_mbs_sess->tmgi = tmgi;
 
     smf_mbs_sess->service_type = ogs_strdup(service_type);
+
+    smf_mbs_sess->mbs_service_area = mbs_service_area;
+    smf_mbs_sess->ext_mbs_service_area = ext_mbs_service_area;
 
     if (ogs_strcasecmp(smf_mbs_sess->service_type, "BROADCAST") == 0) {
         smf_mbs_sess->mbs_session_id.tmgi = tmgi;

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -688,7 +688,7 @@ ogs_tmgi_t *smf_tmgi_allocate(char *expiration_time);
 void smf_tmgi_deallocate(ogs_tmgi_t *tmgi);
 ogs_tmgi_t *smf_tmgi_find_by_tmgi(ogs_tmgi_t *tmgi_to_find);
 
-smf_mbs_sess_t *smf_mbs_sess_create(ogs_tmgi_t *tmgi, ogs_ssm_t *ssm, char *service_type);
+smf_mbs_sess_t *smf_mbs_sess_create(ogs_tmgi_t *tmgi, ogs_ssm_t *ssm, char *service_type, ogs_mbs_service_area_t *mbs_service_area, ogs_ext_mbs_service_area_t *ext_mbs_service_area);
 void smf_mbs_sess_release(smf_mbs_sess_t *smf_mbs_sess);
 
 smf_mbs_sess_t *smf_mbs_sess_find_by_id(ogs_pool_id_t id);

--- a/src/smf/nmbsmf-handler.c
+++ b/src/smf/nmbsmf-handler.c
@@ -571,8 +571,11 @@ bool smf_nmbsmf_handle_mbs_session_create(
     // TODO (borieher): Check provided TMGI is not added to an existing MBS Session
 
     // MBS Session create
-    mbs_sess = smf_mbs_sess_create(tmgi, ssm, service_type);
+    mbs_sess = smf_mbs_sess_create(tmgi, ssm, service_type, mbs_service_area, ext_mbs_service_area);
+    tmgi = NULL; // tmgi passed to mbs_sess
     ssm = NULL; // ssm passed to mbs_sess
+    mbs_service_area = NULL; // mbs_service_area passed to mbs_sess
+    ext_mbs_service_area = NULL; // ext_mbs_service_area passed to mbs_sess
 
     if (!mbs_sess) {
         ogs_error("MBS Session Create: MBS Session Id collides with existing MBS Session");
@@ -585,11 +588,6 @@ bool smf_nmbsmf_handle_mbs_session_create(
 
     mbs_sess->ingress_tun_addr_req = (CreateReqData->mbs_session->is_ingress_tun_addr_req &&
                                       CreateReqData->mbs_session->ingress_tun_addr_req != 0);
-
-    mbs_sess->mbs_service_area = mbs_service_area;
-    mbs_service_area = NULL;
-    mbs_sess->ext_mbs_service_area = ext_mbs_service_area;
-    ext_mbs_service_area = NULL;
 
     if (is_multicast_service) {
         mbs_sess->activity_status = CreateReqData->mbs_session->activity_status;


### PR DESCRIPTION
This fixes a bug where the MB-SMF would sometimes reject a new MBS Session as having the same MBS Session Id as an existing MBS Session even though the areas are different.