### PR TITLE
Improve handling of MBS UDP tunnels

### DIFF
--- a/src/smf/n4mb-handler.c
+++ b/src/smf/n4mb-handler.c
@@ -24,7 +24,7 @@
 // NOTE (borieher): Needed for the SBI request
 #include "sbi-path.h"
 
-
+static const char *_pfcp_cause_to_problem_cause(uint8_t pfcp_cause);
 
 uint8_t smf_n4mb_handle_session_establishment_response(
         smf_mbs_sess_t *mbs_sess, ogs_pfcp_xact_t *xact,
@@ -83,7 +83,7 @@ uint8_t smf_n4mb_handle_session_establishment_response(
     }
 
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
-        ogs_assert(true == ogs_sbi_server_send_error(sbi_stream, 500, NULL, "Unable to establish MBS session", "MBS Session establishment with UPF rejected", "Unknown"));
+        ogs_assert(true == ogs_sbi_server_send_error(sbi_stream, 500, NULL, "Unable to establish MBS session", "MBS Session establishment with UPF rejected", _pfcp_cause_to_problem_cause(cause_value)));
         return cause_value;
     }
 
@@ -305,4 +305,20 @@ uint8_t smf_n4mb_handle_session_establishment_response(
     ogs_assert(r != OGS_ERROR);
 
     return OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
+}
+
+static const char *_pfcp_cause_to_problem_cause(uint8_t pfcp_cause)
+{
+    switch (pfcp_cause) {
+    case OGS_PFCP_CAUSE_MANDATORY_IE_MISSING:
+    case OGS_PFCP_CAUSE_CONDITIONAL_IE_MISSING:
+	return "MANDATORY_IE_MISSING";
+    case OGS_PFCP_CAUSE_INVALID_LENGTH:
+        return "INCORRECT_LENGTH";
+    case OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE:
+        return "INSUFFICIENT_RESOURCES";
+    default:
+        break;
+    }
+    return "SYSTEM_FAILURE";
 }

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -335,14 +335,15 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
 
             // NOTE (borieher): Quick workaround to differentiate between N4 and N4mb
             // the issue is that N4mb information is only present when PLLSSM flag is used
-            if (message->pfcp_session_establishment_response.mbs_session_n4mb_information.presence) {
-                // Find MBS Session by the SEID
-                if (message->h.seid_presence && message->h.seid != 0) {
-                    mbs_sess = smf_mbs_sess_find_by_seid(message->h.seid);
-                } else if (xact->local_seid) { /* rx no SEID or SEID=0 */
-                    mbs_sess = smf_mbs_sess_find_by_seid(xact->local_seid);
-                }
-
+            if (message->h.seid_presence && message->h.seid != 0) {
+                mbs_sess = smf_mbs_sess_find_by_seid(message->h.seid);
+            }
+            if (!mbs_sess && xact->local_seid && (!message->h.seid_presence || message->h.seid == 0) &&
+                message->pfcp_session_establishment_response.mbs_session_n4mb_information.presence) {
+                // Try to find MBS Session by the transaction SEID
+                mbs_sess = smf_mbs_sess_find_by_seid(xact->local_seid);
+            }
+            if (mbs_sess) {
                 smf_n4mb_handle_session_establishment_response(mbs_sess, xact,
                     &message->pfcp_session_establishment_response);
                 break;

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -35,6 +35,9 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess);
 
 static void upf_mbs_sess_remove(upf_mbs_sess_t *upf_mbs_sess);
 static void upf_mbs_sess_remove_all(void);
+static unsigned long long _ull_from_string(const char *str, unsigned long long min_value, unsigned long long max_value,
+                                           char **error_string);
+static uint16_t _uint16_from_string(const char *str, uint16_t min_value, uint16_t max_value, char **error_string);
 
 void upf_context_init(void)
 {
@@ -218,7 +221,13 @@ int upf_context_parse_config(void)
                                     if (ogs_yaml_iter_type(&upf_mbs_tunnel_port_iter) == YAML_SCALAR_NODE) {
                                         /* single value = single port (0=ephemeral) */
                                         const char *upf_mbs_tunnel_port_str = ogs_yaml_iter_value(&upf_mbs_tunnel_port_iter);
-                                        uint16_t upf_mbs_tunnel_port = (uint16_t)ogs_uint64_from_string(upf_mbs_tunnel_port_str);
+                                        char *error = NULL;
+                                        uint16_t upf_mbs_tunnel_port = _uint16_from_string(upf_mbs_tunnel_port_str, 0, 0xfffe, &error);
+                                        if (error) {
+                                            ogs_error("UDP tunnel port error: %s", error);
+                                            ogs_free(error);
+                                            return OGS_ERROR;
+                                        }
                                         if (upf_mbs_tunnel_port) {
                                             self.mbs_udp_tun_ephemeral_port = false;
                                             self.mbs_udp_tun_num_of_ports = 1;
@@ -235,16 +244,44 @@ int upf_context_parse_config(void)
                                         uint16_t start_port = 0, end_port = 0;
                                         while (ogs_yaml_iter_next(&upf_mbs_tunnel_port_iter)) {
                                             const char *upf_mbs_tunnel_port_key = ogs_yaml_iter_key(&upf_mbs_tunnel_port_iter);
-                                            if (ogs_yaml_iter_type(&upf_mbs_tunnel_port_iter) == YAML_SCALAR_NODE) {
-                                                if (!strcmp(upf_mbs_tunnel_port_key, "start")) {
-                                                    start_port = (uint16_t)ogs_uint64_from_string(ogs_yaml_iter_value(&upf_mbs_tunnel_port_iter));
-                                                } else if (!strcmp(upf_mbs_tunnel_port_key, "end")) {
-                                                    end_port = (uint16_t)ogs_uint64_from_string(ogs_yaml_iter_value(&upf_mbs_tunnel_port_iter));
+                                            if (!strcmp(upf_mbs_tunnel_port_key, "start")) {
+                                                ogs_yaml_iter_t upf_mbs_tunnel_port_start_iter;
+                                                ogs_yaml_iter_recurse(&upf_mbs_tunnel_port_iter, &upf_mbs_tunnel_port_start_iter);
+                                                if (ogs_yaml_iter_type(&upf_mbs_tunnel_port_start_iter) == YAML_SCALAR_NODE) {
+                                                    const char *start_val = ogs_yaml_iter_value(&upf_mbs_tunnel_port_start_iter);
+                                                    char *error = NULL;
+                                                    start_port = _uint16_from_string(start_val, 0, 0xfffe, &error);
+                                                    if (error) {
+                                                        ogs_error("UDP tunnel start port error: %s", error);
+                                                        ogs_free(error);
+                                                        return OGS_ERROR;
+                                                    }
+                                                    if (start_port == 0) {
+                                                        ogs_warn("UDP tunnel start port is 0, ephemeral port allocation will be used");
+                                                    }
                                                 } else {
-                                                    ogs_warn("unknown key `%s` in upf/mbs/udptunnel/port section", upf_mbs_tunnel_port_key);
+                                                    ogs_warn("wrong type for key `%s` in upf/mbs/udptunnel/port section, ignoring", upf_mbs_tunnel_port_key);
+                                                }
+                                            } else if (!strcmp(upf_mbs_tunnel_port_key, "end")) {
+                                                ogs_yaml_iter_t upf_mbs_tunnel_port_end_iter;
+                                                ogs_yaml_iter_recurse(&upf_mbs_tunnel_port_iter, &upf_mbs_tunnel_port_end_iter);
+                                                if (ogs_yaml_iter_type(&upf_mbs_tunnel_port_end_iter) == YAML_SCALAR_NODE) {
+                                                    const char *end_val = ogs_yaml_iter_value(&upf_mbs_tunnel_port_end_iter);
+                                                    char *error = NULL;
+                                                    end_port = _uint16_from_string(end_val, 0, 0xfffe, &error);
+                                                    if (error) {
+                                                        ogs_error("UDP tunnel end port error: %s", error);
+                                                        ogs_free(error);
+                                                        return OGS_ERROR;
+                                                    }
+                                                    if (end_port == 0) {
+                                                        ogs_warn("UDP tunnel end port is 0, ephemeral port allocation will be used");
+                                                    }
+                                                } else {
+                                                    ogs_warn("wrong type for key `%s` in upf/mbs/udptunnel/port section, ignoring", upf_mbs_tunnel_port_key);
                                                 }
                                             } else {
-                                                ogs_warn("wrong type for key `%s` in upf/mbs/udptunnel/port section, ignoring", upf_mbs_tunnel_port_key);
+                                                ogs_warn("unknown key `%s` in upf/mbs/udptunnel/port section", upf_mbs_tunnel_port_key);
                                             }
                                         }
                                         if (!start_port || !end_port) {
@@ -267,17 +304,32 @@ int upf_context_parse_config(void)
                                                  self.mbs_udp_tun_ports_free[i] = self.mbs_udp_tun_ports + i;
                                             }
                                         }
-                                    } else if  (ogs_yaml_iter_type(&upf_mbs_tunnel_iter) == YAML_SEQUENCE_NODE) {
+                                    } else if  (ogs_yaml_iter_type(&upf_mbs_tunnel_port_iter) == YAML_SEQUENCE_NODE) {
                                         /* array value = list of port numbers */
-                                        size_t num_of_ports;
+                                        size_t num_of_ports = 0;
                                         bool ephemeral = false;
                                         while (ogs_yaml_iter_next(&upf_mbs_tunnel_port_iter)) {
-                                            uint16_t port = (uint16_t)ogs_uint64_from_string(ogs_yaml_iter_value(&upf_mbs_tunnel_port_iter));
-                                            if (!port) {
-                                                ephemeral = true;
-                                                break;
+                                            ogs_yaml_iter_t upf_mbs_tunnel_port_value_iter;
+                                            ogs_yaml_iter_recurse(&upf_mbs_tunnel_port_iter, &upf_mbs_tunnel_port_value_iter);
+                                            if (ogs_yaml_iter_type(&upf_mbs_tunnel_port_value_iter) == YAML_SCALAR_NODE) {
+                                                char *error = NULL;
+                                                const char *port_val = ogs_yaml_iter_value(&upf_mbs_tunnel_port_value_iter);
+                                                uint16_t port = _uint16_from_string(port_val, 0, 0xfffe, &error);
+                                                if (error) {
+                                                    ogs_error("UDP tunnel port value error: %s", error);
+                                                    ogs_free(error);
+                                                    return OGS_ERROR;
+                                                }
+                                                if (port == 0) {
+                                                    ogs_warn("UDP tunnel port is 0, ephemeral port allocation will be used");
+                                                    ephemeral = true;
+                                                    break;
+                                                }
+                                                num_of_ports++;
+                                            } else {
+                                                ogs_error("UDP tunnel port value error: Value is not a scalar type");
+                                                return OGS_ERROR;
                                             }
-                                            num_of_ports++;
                                         }
                                         if (ephemeral) {
                                             self.mbs_udp_tun_ephemeral_port = true;
@@ -289,11 +341,17 @@ int upf_context_parse_config(void)
                                             self.mbs_udp_tun_ports_next_free = num_of_ports;
                                             ogs_yaml_iter_recurse(&upf_mbs_tunnel_iter, &upf_mbs_tunnel_port_iter);
                                             for (i=0; ogs_yaml_iter_next(&upf_mbs_tunnel_port_iter); i++) {
-                                                self.mbs_udp_tun_ports[i] = (uint16_t)ogs_uint64_from_string(ogs_yaml_iter_value(&upf_mbs_tunnel_port_iter));
+                                                ogs_yaml_iter_t upf_mbs_tunnel_port_value_iter;
+                                                ogs_yaml_iter_recurse(&upf_mbs_tunnel_port_iter, &upf_mbs_tunnel_port_value_iter);
+                                                const char *str = ogs_yaml_iter_value(&upf_mbs_tunnel_port_value_iter);
+                                                self.mbs_udp_tun_ports[i] = _uint16_from_string(str, 0, 0xfffe, NULL);
                                                 self.mbs_udp_tun_ports_free[i] = self.mbs_udp_tun_ports + i;
                                             }
                                             self.mbs_udp_tun_num_of_ports = i;
                                         }
+                                    } else {
+                                        ogs_error("Unknown YAML node type");
+                                        return OGS_ERROR;
                                     }
                                 } else {
                                     ogs_warn("unknown key `%s` in upf/mbs/udptunnel section", upf_mbs_tunnel_key);
@@ -1139,7 +1197,7 @@ static void upf_mbs_sess_remove(upf_mbs_sess_t *upf_mbs_sess)
     if (upf_mbs_sess->udp_tunnel) {
         // Add tunnel port back into the free pool
         if (!self.mbs_udp_tun_ephemeral_port) {
-            uint16_t port = upf_mbs_sess->udp_tunnel->local_addr.ogs_sin_port;
+            uint16_t port = ntohs(upf_mbs_sess->udp_tunnel->local_addr.ogs_sin_port);
             size_t i;
             for (i=0; i < self.mbs_udp_tun_num_of_ports && self.mbs_udp_tun_ports[i] != port; i++);
             if (i < self.mbs_udp_tun_num_of_ports) {
@@ -1152,6 +1210,13 @@ static void upf_mbs_sess_remove(upf_mbs_sess_t *upf_mbs_sess)
     if (upf_mbs_sess->udp_tunnel_pkbuf_pool) {
         ogs_pkbuf_pool_destroy(upf_mbs_sess->udp_tunnel_pkbuf_pool);
         upf_mbs_sess->udp_tunnel_pkbuf_pool = NULL;
+    }
+
+    if (upf_mbs_sess->mbs_session_id.ssm) {
+	ogs_free(upf_mbs_sess->mbs_session_id.ssm);
+    }
+    if (upf_mbs_sess->mbs_session_id.nid) {
+        ogs_free(upf_mbs_sess->mbs_session_id.nid);
     }
 }
 
@@ -1243,4 +1308,30 @@ void upf_mbs_sess_set_llssm(upf_mbs_sess_t *mbs_sess)
     ogs_assert(mbs_sess);
 
     mbs_sess->ll_ssm = ogs_pfcp_llssm_add();
+}
+
+static unsigned long long _ull_from_string(const char *str, unsigned long long min_value, unsigned long long max_value,
+                                           char **error_string)
+{
+    unsigned long long val = 0;
+    if (str) {
+        char *end_ptr = NULL;
+        val = strtoull(str, &end_ptr, 0);
+        if (!end_ptr || *end_ptr != '\0') {
+            if (error_string)
+                *error_string = ogs_msprintf("The string \"%s\" could not be parsed as an unsigned integer", str);
+            return 0;
+        }
+    }
+    if (val < min_value || val > max_value) {
+        if (error_string)
+            *error_string = ogs_msprintf("Value %llu out of range: value must be between %llu and %llu inclusive", val, min_value, max_value);
+        return 0;
+    }
+    return val;
+}
+
+static uint16_t _uint16_from_string(const char *str, uint16_t min_value, uint16_t max_value, char **error_string)
+{
+    return (uint16_t)_ull_from_string(str, (unsigned long long)min_value, (unsigned long long)max_value, error_string);
 }

--- a/src/upf/n4mb-handler.c
+++ b/src/upf/n4mb-handler.c
@@ -47,7 +47,7 @@ void upf_n4mb_handle_session_establishment_request(
 
     int i;
     uint8_t cause_value = 0;
-    uint8_t offending_ie_value = 0;
+    uint16_t offending_ie_value = 0;
 
     ogs_pfcp_pdr_t *pdr = NULL;
     ogs_pfcp_far_t *far = NULL;
@@ -72,9 +72,11 @@ void upf_n4mb_handle_session_establishment_request(
 
     for (i = 0; i < OGS_MAX_NUM_OF_PDR; i++) {
         // NOTE (borieher): Put sereq_flags to NULL?
+        uint8_t offending_ie_value_tmp = 0;
         created_pdr[i] = ogs_pfcp_handle_create_pdr(&mbs_sess->pfcp,
                 &req->create_pdr[i], NULL,
-                &cause_value, &offending_ie_value);
+                &cause_value, &offending_ie_value_tmp);
+        offending_ie_value = offending_ie_value_tmp;
         if (created_pdr[i] == NULL)
             break;
     }
@@ -84,9 +86,13 @@ void upf_n4mb_handle_session_establishment_request(
         goto cleanup;
 
     for (i = 0; i < OGS_MAX_NUM_OF_FAR; i++) {
+        uint8_t offending_ie_value_tmp = 0;
         if (ogs_pfcp_handle_create_far(&mbs_sess->pfcp, &req->create_far[i],
-                    &cause_value, &offending_ie_value) == NULL)
+                    &cause_value, &offending_ie_value_tmp) == NULL) {
+            offending_ie_value = offending_ie_value_tmp;
             break;
+        }
+        offending_ie_value = offending_ie_value_tmp;
     }
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED)
         goto cleanup;
@@ -105,9 +111,13 @@ void upf_n4mb_handle_session_establishment_request(
     }
 
     for (i = 0; i < OGS_MAX_NUM_OF_QER; i++) {
+        uint8_t offending_ie_value_tmp = 0;
         if (ogs_pfcp_handle_create_qer(&mbs_sess->pfcp, &req->create_qer[i],
-                    &cause_value, &offending_ie_value) == NULL)
+                    &cause_value, &offending_ie_value_tmp) == NULL) {
+            offending_ie_value = offending_ie_value_tmp;
             break;
+        }
+        offending_ie_value = offending_ie_value_tmp;
     }
     if (cause_value != OGS_PFCP_CAUSE_REQUEST_ACCEPTED)
         goto cleanup;
@@ -122,9 +132,29 @@ void upf_n4mb_handle_session_establishment_request(
                     ogs_sockaddr_t *bind_address = NULL;
                     upf_context_t *ctx = upf_self();
                     ogs_copyaddrinfo(&bind_address, ctx->mbs_udp_tun_base_addr);
-                    bind_address->ogs_sin_port = _get_next_udp_tunnel_port(ctx);
+                    bind_address->ogs_sin_port = htons(_get_next_udp_tunnel_port(ctx));
+                    if (bind_address->ogs_sin_port == 0xffff) {
+                        // Error already reported, abort MBS Session
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        ogs_freeaddrinfo(bind_address);
+                        goto cleanup;
+                    }
                     mbs_sess->udp_tunnel = ogs_sock_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-                    ogs_sock_bind(mbs_sess->udp_tunnel, bind_address);
+                    if (!mbs_sess->udp_tunnel) {
+                        ogs_error("Failed to create socket for UDP tunnel");
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        ogs_freeaddrinfo(bind_address);
+                        goto cleanup;
+                    }
+                    if (ogs_sock_bind(mbs_sess->udp_tunnel, bind_address) != OGS_OK) {
+                        ogs_error("Failed to bind to UDP tunnel for listening");
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        ogs_freeaddrinfo(bind_address);
+                        goto cleanup;
+                    }
                     // get the true local address to fill in ephemeral ports.
                     socklen_t name_len = sizeof(mbs_sess->udp_tunnel->local_addr.ss);
                     getsockname(mbs_sess->udp_tunnel->fd, (struct sockaddr*)&mbs_sess->udp_tunnel->local_addr.ss, &name_len);
@@ -134,17 +164,57 @@ void upf_n4mb_handle_session_establishment_request(
                     mbs_sess->udp_tunnel_mtu = mtu - sizeof(struct ether_header) - sizeof(struct iphdr) - sizeof(struct udphdr);
                     ogs_debug("UDP tunnel using MTU of %i (%i after overheads)", mtu, mbs_sess->udp_tunnel_mtu);
                     ogs_pkbuf_config_t *config = _udp_tunnel_make_pool_config(mbs_sess->udp_tunnel_mtu, 32); /* 32 buffers */
+                    if (!config) {
+                        ogs_error("Failed to allocate packet buffers configuration for UDP tunnel");
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        goto cleanup;
+                    }
                     mbs_sess->udp_tunnel_pkbuf_pool = ogs_pkbuf_pool_create(config);
                     ogs_free(config);
-                    ogs_pollset_add(ogs_app()->pollset, OGS_POLLIN, mbs_sess->udp_tunnel->fd, _mbs_tunnel_poll_handler, mbs_sess);
+#if OGS_USE_TALLOC == 0
+                    if (!mbs_sess->udp_tunnel_pkbuf_pool) {
+                        ogs_error("Failed to allocate 32 x %u byte packet buffers for UDP tunnel", mbs_sess->udp_tunnel_mtu);
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        goto cleanup;
+                    }
+#endif
+                    mbs_sess->udp_tunnel_poll = ogs_pollset_add(ogs_app()->pollset, OGS_POLLIN, mbs_sess->udp_tunnel->fd, _mbs_tunnel_poll_handler, mbs_sess);
+                    if (!mbs_sess->udp_tunnel_poll) {
+                        ogs_error("Failed to add UDP tunnel to pollset");
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        goto cleanup;
+                    }
                 } else if (lit->ipv6) {
                     // Create IPv6 UDP tunnel endpoint and return the address & port in the session response
                     ogs_sockaddr_t *bind_address = NULL;
                     upf_context_t *ctx = upf_self();
                     ogs_copyaddrinfo(&bind_address, ctx->mbs_udp_tun_base_addr);
-                    bind_address->sin6.sin6_port = _get_next_udp_tunnel_port(ctx);
+                    bind_address->sin6.sin6_port = htons(_get_next_udp_tunnel_port(ctx));
+                    if (bind_address->sin6.sin6_port == 0xffff) {
+                        // Error already reported, abort MBS Session
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        ogs_freeaddrinfo(bind_address);
+                        goto cleanup;
+                    }
                     mbs_sess->udp_tunnel = ogs_sock_socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
-                    ogs_sock_bind(mbs_sess->udp_tunnel, bind_address);
+                    if (!mbs_sess->udp_tunnel) {
+                        ogs_error("Failed to create socket for UDP tunnel");
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        ogs_freeaddrinfo(bind_address);
+                        goto cleanup;
+                    }
+                    if (ogs_sock_bind(mbs_sess->udp_tunnel, bind_address) != OGS_OK) {
+                        ogs_error("Failed to bind to UDP tunnel for listening");
+                        cause_value = OGS_PFCP_CAUSE_SYSTEM_FAILURE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        ogs_freeaddrinfo(bind_address);
+                        goto cleanup;
+                    }
                     // get the true local address to fill in ephemeral ports.
                     socklen_t name_len = sizeof(mbs_sess->udp_tunnel->local_addr.ss);
                     getsockname(mbs_sess->udp_tunnel->fd, (struct sockaddr*)&mbs_sess->udp_tunnel->local_addr.ss, &name_len);
@@ -154,9 +224,27 @@ void upf_n4mb_handle_session_establishment_request(
                     mbs_sess->udp_tunnel_mtu = mtu - sizeof(struct ether_header) - sizeof(struct ip6_hdr) - sizeof(struct udphdr);
                     ogs_debug("UDP tunnel using MTU of %i (%i after overheads)", mtu, mbs_sess->udp_tunnel_mtu);
                     ogs_pkbuf_config_t *config = _udp_tunnel_make_pool_config(mbs_sess->udp_tunnel_mtu, 32); /* 32 buffers */
+                    if (!config) {
+                        ogs_error("Failed to allocate packet buffers configuration for UDP tunnel");
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        goto cleanup;
+                    }
                     mbs_sess->udp_tunnel_pkbuf_pool = ogs_pkbuf_pool_create(config);
                     ogs_free(config);
-                    ogs_pollset_add(ogs_app()->pollset, OGS_POLLIN, mbs_sess->udp_tunnel->fd, _mbs_tunnel_poll_handler, mbs_sess);
+                    if (!mbs_sess->udp_tunnel_pkbuf_pool) {
+                        ogs_error("Failed to allocate 32 x %u byte packet buffers for UDP tunnel", mbs_sess->udp_tunnel_mtu);
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        goto cleanup;
+                    }
+                    mbs_sess->udp_tunnel_poll = ogs_pollset_add(ogs_app()->pollset, OGS_POLLIN, mbs_sess->udp_tunnel->fd, _mbs_tunnel_poll_handler, mbs_sess);
+                    if (!mbs_sess->udp_tunnel_poll) {
+                        ogs_error("Failed to add UDP tunnel to pollset");
+                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
+                        goto cleanup;
+                    }
                 }
             } else {
                 if (lit->ipv4) {
@@ -347,6 +435,18 @@ void upf_n4mb_handle_session_establishment_request(
 
 cleanup:
     ogs_pfcp_sess_clear(&mbs_sess->pfcp);
+    if (mbs_sess->udp_tunnel) {
+        ogs_sock_destroy(mbs_sess->udp_tunnel);
+        mbs_sess->udp_tunnel = NULL;
+    }
+    if (mbs_sess->udp_tunnel_pkbuf_pool) {
+        ogs_pkbuf_pool_destroy(mbs_sess->udp_tunnel_pkbuf_pool);
+        mbs_sess->udp_tunnel_pkbuf_pool = NULL;
+    }
+    if (mbs_sess->udp_tunnel_poll) {
+        ogs_pollset_remove(mbs_sess->udp_tunnel_poll);
+        mbs_sess->udp_tunnel_poll = NULL;
+    }
     ogs_pfcp_send_error_message(xact, mbs_sess ? mbs_sess->smf_n4mb_f_seid.seid : 0,
             OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
             cause_value, offending_ie_value);
@@ -392,6 +492,8 @@ static ogs_pkbuf_config_t *_udp_tunnel_make_pool_config(size_t max_buf_size, siz
 {
     ogs_pkbuf_config_t *config = ogs_calloc(1, sizeof(*config));
     size_t pkbuf_buffer_size = sizeof(ogs_pkbuf_t) + max_buf_size;
+
+    if (!config) return NULL;
     if (pkbuf_buffer_size <= 128) {
         config->cluster_128_pool = 128 * max_buffers;
     } else if (pkbuf_buffer_size <= 256) {
@@ -407,6 +509,7 @@ static ogs_pkbuf_config_t *_udp_tunnel_make_pool_config(size_t max_buf_size, siz
     } else if (pkbuf_buffer_size <= 32768) {
         config->cluster_32768_pool = 32768 * max_buffers;
     } else {
+        // Anything bigger would break maximum path MTU
         config->cluster_big_pool = 65536 * max_buffers;
     }
     return config;

--- a/src/upf/n4mb-handler.c
+++ b/src/upf/n4mb-handler.c
@@ -150,7 +150,7 @@ void upf_n4mb_handle_session_establishment_request(
                     }
                     if (ogs_sock_bind(mbs_sess->udp_tunnel, bind_address) != OGS_OK) {
                         ogs_error("Failed to bind to UDP tunnel for listening");
-                        cause_value = OGS_PFCP_CAUSE_NO_RESOURCES_AVAILABLE;
+                        cause_value = OGS_PFCP_CAUSE_SYSTEM_FAILURE;
                         offending_ie_value = OGS_PFCP_LOCAL_INGRESS_TUNNEL_TYPE;
                         ogs_freeaddrinfo(bind_address);
                         goto cleanup;


### PR DESCRIPTION
Improve the error handling around the use of UDP tunnels with MBS Sessions.

- Improves validation of the MB-UPF UDP tunnel configuration options for port numbers.
- Checks for correct establishment of a listening socket for the UDP tunnel, will return an error if:
   - The pool of configured ports for UDP tunnels has been exhausted.
   - The socket could not be allocated (e.g. run out of available file handles in the process)
   - The socket could not bind to the allocated port
   - The packet buffers for reception could not be allocated
   - The socket could not be added to the set of file descriptors to polling.
- Adds a translation in the MB-SMF for PFCP cause type to *ProblemDetail* cause for forwarding of error responses to (MBSF) client.

Fixes #44