### PR TITLE
Fixes for memory access issues identified by ASAN

### DIFF
--- a/lib/sbi/nnrf-build.c
+++ b/lib/sbi/nnrf-build.c
@@ -127,7 +127,7 @@ OpenAPI_nf_profile_t *ogs_nnrf_nfm_build_nf_profile(
         CollocatedNfInstances = OpenAPI_list_create();
         ogs_list_for_each(&nf_instance->collocated_nf_list, node) {
 	    OpenAPI_collocated_nf_instance_t *coll_nf_inst =
-                    OpenAPI_collocated_nf_instance_create(node->collocated_nf_instance.nf_instance_id,
+                    OpenAPI_collocated_nf_instance_create(ogs_strdup(node->collocated_nf_instance.nf_instance_id),
                             node->collocated_nf_instance.nf_type);
 	    OpenAPI_list_add(CollocatedNfInstances, coll_nf_inst);
         }
@@ -419,13 +419,11 @@ void ogs_nnrf_nfm_free_nf_profile(OpenAPI_nf_profile_t *NFProfile)
     if (NFProfile->fqdn)
         ogs_free(NFProfile->fqdn);
 
-#if 0
     if (NFProfile->collocated_nf_instances) {
         OpenAPI_list_for_each(NFProfile->collocated_nf_instances, node)
             OpenAPI_collocated_nf_instance_free((OpenAPI_collocated_nf_instance_t*)node->data);
         OpenAPI_list_free(NFProfile->collocated_nf_instances);
     }
-#endif
 
     OpenAPI_list_for_each(NFProfile->ipv4_addresses, node)
         ogs_free(node->data);

--- a/src/amf/namf-handler.c
+++ b/src/amf/namf-handler.c
@@ -1623,13 +1623,11 @@ static ogs_nas_ue_security_capability_t
 
     memset(&ue_security_capability, 0, sizeof(ue_security_capability));
     ue_security_capability_octets_string =
-            (char*) ogs_calloc(sizeof(ue_security_capability), sizeof(char));
+            (char*) ogs_calloc(sizeof(ue_security_capability)+1, sizeof(char));
     ogs_assert(ue_security_capability_octets_string);
 
+    ogs_assert(ogs_base64_decode_len(encoded) <= sizeof(ue_security_capability)+1);
     ogs_base64_decode(ue_security_capability_octets_string, encoded);
-
-    ogs_assert(sizeof(ue_security_capability_octets_string) <=
-            sizeof(ogs_nas_ue_security_capability_t) + 1);
 
     ue_security_capability_iei = // not copied anywhere for now
             ue_security_capability_octets_string[0];

--- a/src/hss/hss-cx-path.c
+++ b/src/hss/hss-cx-path.c
@@ -441,7 +441,7 @@ static int hss_ogs_diam_cx_mar_cb( struct msg **msg, struct avp *avp,
     ogs_log_print(OGS_LOG_DEBUG, "ik - ");
     ogs_log_hexdump(OGS_LOG_DEBUG, ik, OGS_KEY_LEN);
     ogs_log_print(OGS_LOG_DEBUG, "ak - ");
-    ogs_log_hexdump(OGS_LOG_DEBUG, ak, OGS_KEY_LEN);
+    ogs_log_hexdump(OGS_LOG_DEBUG, ak, OGS_AK_LEN);
     ogs_log_print(OGS_LOG_DEBUG, "xles - ");
     ogs_log_hexdump(OGS_LOG_DEBUG, xres, xres_len);
 

--- a/src/hss/hss-swx-path.c
+++ b/src/hss/hss-swx-path.c
@@ -223,7 +223,7 @@ static int hss_ogs_diam_swx_mar_cb( struct msg **msg, struct avp *avp,
     ogs_log_print(OGS_LOG_DEBUG, "ik - ");
     ogs_log_hexdump(OGS_LOG_DEBUG, ik, OGS_KEY_LEN);
     ogs_log_print(OGS_LOG_DEBUG, "ak - ");
-    ogs_log_hexdump(OGS_LOG_DEBUG, ak, OGS_KEY_LEN);
+    ogs_log_hexdump(OGS_LOG_DEBUG, ak, OGS_AK_LEN);
     ogs_log_print(OGS_LOG_DEBUG, "xles - ");
     ogs_log_hexdump(OGS_LOG_DEBUG, xres, xres_len);
 

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1908,7 +1908,9 @@ smf_sess_t *smf_sess_find_by_teid(uint32_t teid)
 
 smf_sess_t *smf_sess_find_by_seid(uint64_t seid)
 {
-    return ogs_hash_get(self.smf_n4_seid_hash, &seid, sizeof(seid));
+    smf_sess_t *sess = ogs_hash_get(self.smf_n4_seid_hash, &seid, sizeof(seid));
+    if (sess && sess != smf_sess_find_by_id(sess->id)) sess = NULL;
+    return sess;
 }
 
 smf_sess_t *smf_sess_find_by_apn(smf_ue_t *smf_ue, char *apn, uint8_t rat_type)
@@ -3590,7 +3592,9 @@ void smf_mbs_sess_release(smf_mbs_sess_t *smf_mbs_sess)
 
 smf_mbs_sess_t *smf_mbs_sess_find_by_seid(uint64_t seid)
 {
-    return ogs_hash_get(self.smf_n4_seid_hash, &seid, sizeof(seid));
+    smf_mbs_sess_t *mbs_sess = ogs_hash_get(self.smf_n4_seid_hash, &seid, sizeof(seid));
+    if (mbs_sess && mbs_sess != smf_mbs_sess_find_by_id(mbs_sess->id)) mbs_sess = NULL;
+    return mbs_sess;
 }
 
 // TODO (borieher): Select UPF based on MBS parameters


### PR DESCRIPTION
These are some fixes for issues identified by the address sanitiser (ASAN) during testing on MBS features.
- Fix heap read overflow in AMF
- Fix stack read overflow in HSS logging
- Fix memory leak on collocatedNfInstance objects
- Make the SMF smf_mbs_sess_find_by_seid() and smf_sess_find_by_seid() more robust.
    - smf_mbs_sess_find_by_seid() will only return smf_mbs_sess_t pointers and not typecast smf_sess_t pointers.
    - smf_sess_find_by_seid() will only return smf_sess_t pointers and not typecast smf_mbs_sess_t pointers.
    - This prevents subsequent heap read/write overflows.